### PR TITLE
fix: CIをrelease以外の全ブランチpushで実行するよう変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [develop, release]
   push:
-    branches: [develop]
+    branches-ignore: [release]
 
 jobs:
   test:


### PR DESCRIPTION
- CIのpushトリガーを `branches: [develop]` から `branches-ignore: [release]` に変更
- featureブランチへのpushでもCIが実行されるようになる
- releaseブランチはrelease.ymlが担当するため除外