### PR TITLE
feat: WikitextMode / WikitextSettings を導入

### DIFF
--- a/packages/ast/src/index.ts
+++ b/packages/ast/src/index.ts
@@ -84,3 +84,7 @@ export {
   isContainerTypeParagraphSafe,
   isParagraphSafe,
 } from "./element";
+
+// Wikitext settings
+export type { WikitextMode, WikitextSettings } from "./settings";
+export { createSettings, DEFAULT_SETTINGS } from "./settings";

--- a/packages/ast/src/settings.ts
+++ b/packages/ast/src/settings.ts
@@ -26,6 +26,12 @@ export interface WikitextSettings {
    * when multiple rendered fragments appear on the same page.
    */
   useTrueIds: boolean;
+  /**
+   * Whether [[module CSS]] style elements are rendered as <style> tags.
+   * Disable to prevent user-authored CSS from affecting the page layout
+   * (e.g., in draft previews, forum posts).
+   */
+  allowStyleElements: boolean;
 }
 
 /**
@@ -34,12 +40,30 @@ export interface WikitextSettings {
 export function createSettings(mode: WikitextMode): WikitextSettings {
   switch (mode) {
     case "page":
-      return { mode, enablePageSyntax: true, allowLocalPaths: true, useTrueIds: true };
+      return {
+        mode,
+        enablePageSyntax: true,
+        allowLocalPaths: true,
+        useTrueIds: true,
+        allowStyleElements: true,
+      };
     case "draft":
-      return { mode, enablePageSyntax: true, allowLocalPaths: true, useTrueIds: false };
+      return {
+        mode,
+        enablePageSyntax: true,
+        allowLocalPaths: true,
+        useTrueIds: false,
+        allowStyleElements: false,
+      };
     case "forum-post":
     case "direct-message":
-      return { mode, enablePageSyntax: false, allowLocalPaths: false, useTrueIds: false };
+      return {
+        mode,
+        enablePageSyntax: false,
+        allowLocalPaths: false,
+        useTrueIds: false,
+        allowStyleElements: false,
+      };
   }
 }
 

--- a/packages/ast/src/settings.ts
+++ b/packages/ast/src/settings.ts
@@ -1,0 +1,47 @@
+/**
+ * Wikitext parsing/rendering mode.
+ * Each mode has different default settings for syntax availability.
+ */
+export type WikitextMode = "page" | "draft" | "forum-post" | "direct-message";
+
+/**
+ * Settings that control parser and renderer behavior based on context.
+ */
+export interface WikitextSettings {
+  /** Operating mode */
+  mode: WikitextMode;
+  /**
+   * Whether page-contextual syntax is permitted.
+   * Controls: include, module, table-of-contents.
+   */
+  enablePageSyntax: boolean;
+  /**
+   * Whether local file paths (file1, file2, file3) are permitted for images.
+   * Disable in contexts without a "local" page (forum posts, direct messages).
+   */
+  allowLocalPaths: boolean;
+  /**
+   * Whether element IDs should be stable sequential values.
+   * When false, IDs are randomized to prevent collisions
+   * when multiple rendered fragments appear on the same page.
+   */
+  useTrueIds: boolean;
+}
+
+/**
+ * Create WikitextSettings with defaults for the given mode.
+ */
+export function createSettings(mode: WikitextMode): WikitextSettings {
+  switch (mode) {
+    case "page":
+      return { mode, enablePageSyntax: true, allowLocalPaths: true, useTrueIds: true };
+    case "draft":
+      return { mode, enablePageSyntax: true, allowLocalPaths: true, useTrueIds: false };
+    case "forum-post":
+    case "direct-message":
+      return { mode, enablePageSyntax: false, allowLocalPaths: false, useTrueIds: false };
+  }
+}
+
+/** Default settings (page mode) */
+export const DEFAULT_SETTINGS: WikitextSettings = createSettings("page");

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -54,6 +54,10 @@ export {
   listItemSubList,
 } from "@wdprlib/ast";
 
+// Wikitext settings (re-exported from @wdprlib/ast)
+export type { WikitextMode, WikitextSettings } from "@wdprlib/ast";
+export { createSettings, DEFAULT_SETTINGS } from "@wdprlib/ast";
+
 // Lexer
 export type { TokenType, Token, LexerOptions } from "./lexer";
 export { Lexer, tokenize, createToken } from "./lexer";

--- a/packages/parser/src/parser/parse.ts
+++ b/packages/parser/src/parser/parse.ts
@@ -1,7 +1,8 @@
 import type { Token } from "../lexer";
 import { tokenize } from "../lexer";
 import { preprocess } from "./preprocess";
-import type { Element, SyntaxTree } from "@wdprlib/ast";
+import type { Element, SyntaxTree, WikitextSettings } from "@wdprlib/ast";
+import { DEFAULT_SETTINGS } from "@wdprlib/ast";
 import { blockRules, blockFallbackRule, inlineRules, type ParseContext } from "./rules";
 import { canApplyBlockRule } from "./rules/block/utils";
 import { mergeSpanStripParagraphs, cleanInternalFlags } from "./postprocess";
@@ -15,6 +16,8 @@ export interface ParserOptions {
   version?: "wikidot";
   /** Track position information */
   trackPositions?: boolean;
+  /** Wikitext settings controlling syntax availability */
+  settings?: WikitextSettings;
 }
 
 /**
@@ -29,6 +32,7 @@ export class Parser {
       pos: 0,
       version: options.version ?? "wikidot",
       trackPositions: options.trackPositions ?? true,
+      settings: options.settings ?? DEFAULT_SETTINGS,
       // Collections for SyntaxTree output (populated during parsing)
       footnotes: [],
       tocEntries: [],

--- a/packages/parser/src/parser/rules/block/include.ts
+++ b/packages/parser/src/parser/rules/block/include.ts
@@ -85,6 +85,12 @@ export const includeRule: BlockRule = {
     if (!nameResult || nameResult.name.toLowerCase() !== "include") {
       return { success: false };
     }
+
+    // Page syntax disabled (e.g., forum-post mode)
+    if (!ctx.settings.enablePageSyntax) {
+      return { success: false };
+    }
+
     pos += nameResult.consumed;
     consumed += nameResult.consumed;
 

--- a/packages/parser/src/parser/rules/block/module.ts
+++ b/packages/parser/src/parser/rules/block/module.ts
@@ -24,6 +24,11 @@ export const moduleRule: BlockRule = {
       return { success: false };
     }
 
+    // Page syntax disabled (e.g., forum-post mode)
+    if (!ctx.settings.enablePageSyntax) {
+      return { success: false };
+    }
+
     pos += nameResult.consumed;
     consumed += nameResult.consumed;
 

--- a/packages/parser/src/parser/rules/block/module/include/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/include/resolve.ts
@@ -5,7 +5,7 @@
  * allowing block structures (like div) to span across include boundaries.
  */
 
-import type { PageRef, VariableMap } from "@wdprlib/ast";
+import type { PageRef, VariableMap, WikitextSettings } from "@wdprlib/ast";
 
 /**
  * Callback to fetch page content for include resolution.
@@ -23,6 +23,8 @@ export type IncludeFetcher = (pageRef: PageRef) => string | null;
 export interface ResolveIncludesOptions {
   /** Maximum recursion depth for nested includes (default: 5) */
   maxDepth?: number;
+  /** Wikitext settings. If enablePageSyntax is false, includes are not expanded. */
+  settings?: WikitextSettings;
 }
 
 /**
@@ -44,6 +46,10 @@ export function resolveIncludes(
   fetcher: IncludeFetcher,
   options?: ResolveIncludesOptions,
 ): string {
+  if (options?.settings && !options.settings.enablePageSyntax) {
+    return source;
+  }
+
   const maxDepth = options?.maxDepth ?? 5;
   const cache = new Map<string, string | null>();
 

--- a/packages/parser/src/parser/rules/block/toc.ts
+++ b/packages/parser/src/parser/rules/block/toc.ts
@@ -61,6 +61,10 @@ export const tocRule: BlockRule = {
 
     if (firstValue === "toc") {
       // [[toc ...]]
+      // Page syntax disabled (e.g., forum-post mode)
+      if (!ctx.settings.enablePageSyntax) {
+        return { success: false };
+      }
       pos++;
     } else if (firstValue === "f") {
       // Possibly [[f<toc ...]] or [[f>toc ...]]
@@ -86,6 +90,10 @@ export const tocRule: BlockRule = {
         return { success: false };
       }
       if (tocToken.value.toLowerCase() !== "toc") {
+        return { success: false };
+      }
+      // Page syntax disabled (e.g., forum-post mode)
+      if (!ctx.settings.enablePageSyntax) {
         return { success: false };
       }
       pos++;

--- a/packages/parser/src/parser/rules/types.ts
+++ b/packages/parser/src/parser/rules/types.ts
@@ -1,5 +1,5 @@
 import type { Token, TokenType } from "../../lexer";
-import type { Version } from "@wdprlib/ast";
+import type { Version, WikitextSettings } from "@wdprlib/ast";
 import type { Element, CodeBlockData, TocEntry } from "@wdprlib/ast";
 
 /**
@@ -10,6 +10,7 @@ export interface ParseContext {
   pos: number;
   version: Version;
   trackPositions: boolean;
+  settings: WikitextSettings;
   // Collections for SyntaxTree output
   footnotes: Element[][];
   tocEntries: TocEntry[];

--- a/packages/render/src/context.ts
+++ b/packages/render/src/context.ts
@@ -116,26 +116,31 @@ export class RenderContext {
     return this.options.page;
   }
 
-  /** Resolve an ImageSource to a src URL */
-  resolveImageSource(source: ImageSource): string {
+  /** Resolve an ImageSource to a src URL. Returns null if blocked by settings. */
+  resolveImageSource(source: ImageSource): string | null {
     const pageName = this.page?.pageName;
     switch (source.type) {
       case "url": {
-        // Convert /path to /local--files/path (Wikidot file reference)
         const url = source.data;
+        // Local path (e.g., /local-file.png) — blocked when allowLocalPaths is false
         if (url.startsWith("/") && !url.startsWith("//")) {
+          if (!this.settings.allowLocalPaths) return null;
           return `/local--files${url}`;
         }
         return url;
       }
       case "file1":
-        // file1 uses current page context
-        return pageName
-          ? `/local--files/${pageName}/${source.data.file}`
-          : `/local--files/${source.data.file}`;
       case "file2":
-        return `/local--files/${source.data.page}/${source.data.file}`;
       case "file3":
+        if (!this.settings.allowLocalPaths) return null;
+        if (source.type === "file1") {
+          return pageName
+            ? `/local--files/${pageName}/${source.data.file}`
+            : `/local--files/${source.data.file}`;
+        }
+        if (source.type === "file2") {
+          return `/local--files/${source.data.page}/${source.data.file}`;
+        }
         return `/local--files/${source.data.site}/${source.data.page}/${source.data.file}`;
     }
   }

--- a/packages/render/src/context.ts
+++ b/packages/render/src/context.ts
@@ -21,6 +21,7 @@ export class RenderContext {
   private _equationIndex = 0;
   private _htmlBlockIndex = 0;
   private _bibciteCounter = 0;
+  private _idSuffix: string | null;
 
   readonly settings: WikitextSettings;
   readonly options: RenderOptions;
@@ -35,6 +36,10 @@ export class RenderContext {
 
   constructor(tree: SyntaxTree, options: RenderOptions = {}) {
     this.settings = options.settings ?? DEFAULT_SETTINGS;
+    // When useTrueIds is false, generate a per-context random suffix for all IDs
+    this._idSuffix = this.settings.useTrueIds
+      ? null
+      : Math.random().toString(16).slice(2, 8);
     this.options = options;
     this.footnotes = options.footnotes ?? tree.footnotes ?? [];
     this.styles = tree.styles ?? [];
@@ -109,6 +114,29 @@ export class RenderContext {
   /** Get and increment the bibcite counter (for unique IDs) */
   nextBibciteCounter(): number {
     return ++this._bibciteCounter;
+  }
+
+  /**
+   * Generate an element ID.
+   * When useTrueIds is true, returns `${prefix}${index}`.
+   * When false, appends a random suffix to prevent collisions across fragments.
+   */
+  generateId(prefix: string, index: number | string): string {
+    if (this._idSuffix === null) {
+      return `${prefix}${index}`;
+    }
+    return `${prefix}${index}-${this._idSuffix}`;
+  }
+
+  /**
+   * Generate a fixed element ID (no index).
+   * When useTrueIds is false, appends a random suffix.
+   */
+  generateFixedId(name: string): string {
+    if (this._idSuffix === null) {
+      return name;
+    }
+    return `${name}-${this._idSuffix}`;
   }
 
   /** Get page context */

--- a/packages/render/src/context.ts
+++ b/packages/render/src/context.ts
@@ -1,11 +1,11 @@
 import type {
-	Element,
-	ImageSource,
-	LinkLocation,
-	SyntaxTree,
-	BibliographyBlockData,
-	DefinitionListItem,
-	WikitextSettings,
+  Element,
+  ImageSource,
+  LinkLocation,
+  SyntaxTree,
+  BibliographyBlockData,
+  DefinitionListItem,
+  WikitextSettings,
 } from "@wdprlib/ast";
 import { DEFAULT_SETTINGS } from "@wdprlib/ast";
 import type { RenderOptions, PageContext } from "./types";
@@ -15,230 +15,226 @@ import { escapeHtml, escapeAttr, sanitizeAttributes } from "./escape";
  * Render context - manages state and output buffer during rendering
  */
 export class RenderContext {
-	private chunks: string[] = [];
-	private _tocIndex = 0;
-	private _footnoteIndex = 0;
-	private _equationIndex = 0;
-	private _htmlBlockIndex = 0;
-	private _bibciteCounter = 0;
-	private _idSuffix: string | null;
+  private chunks: string[] = [];
+  private _tocIndex = 0;
+  private _footnoteIndex = 0;
+  private _equationIndex = 0;
+  private _htmlBlockIndex = 0;
+  private _bibciteCounter = 0;
+  private _idSuffix: string | null;
 
-	readonly settings: WikitextSettings;
-	readonly options: RenderOptions;
-	readonly footnotes: Element[][];
-	readonly styles: string[];
-	readonly htmlBlocks: string[];
-	readonly tocElements: Element[];
-	/** Map from bibliography label to citation number (1-indexed) */
-	readonly bibliographyMap: Map<string, number>;
-	/** Bibliography entries (from bibliography-block) */
-	readonly bibliographyEntries: DefinitionListItem[];
+  readonly settings: WikitextSettings;
+  readonly options: RenderOptions;
+  readonly footnotes: Element[][];
+  readonly styles: string[];
+  readonly htmlBlocks: string[];
+  readonly tocElements: Element[];
+  /** Map from bibliography label to citation number (1-indexed) */
+  readonly bibliographyMap: Map<string, number>;
+  /** Bibliography entries (from bibliography-block) */
+  readonly bibliographyEntries: DefinitionListItem[];
 
-	constructor(tree: SyntaxTree, options: RenderOptions = {}) {
-		this.settings = options.settings ?? DEFAULT_SETTINGS;
-		// When useTrueIds is false, generate a per-context random suffix for all IDs
-		this._idSuffix = this.settings.useTrueIds
-			? null
-			: Math.random().toString(16).slice(2, 8);
-		this.options = options;
-		this.footnotes = options.footnotes ?? tree.footnotes ?? [];
-		this.styles = tree.styles ?? [];
-		this.htmlBlocks = tree["html-blocks"] ?? [];
-		this.tocElements = tree["table-of-contents"] ?? [];
+  constructor(tree: SyntaxTree, options: RenderOptions = {}) {
+    this.settings = options.settings ?? DEFAULT_SETTINGS;
+    // When useTrueIds is false, generate a per-context random suffix for all IDs
+    this._idSuffix = this.settings.useTrueIds ? null : Math.random().toString(16).slice(2, 8);
+    this.options = options;
+    this.footnotes = options.footnotes ?? tree.footnotes ?? [];
+    this.styles = tree.styles ?? [];
+    this.htmlBlocks = tree["html-blocks"] ?? [];
+    this.tocElements = tree["table-of-contents"] ?? [];
 
-		// Build bibliography map from tree elements
-		this.bibliographyMap = new Map();
-		this.bibliographyEntries = [];
-		this.buildBibliographyMap(tree.elements);
-	}
+    // Build bibliography map from tree elements
+    this.bibliographyMap = new Map();
+    this.bibliographyEntries = [];
+    this.buildBibliographyMap(tree.elements);
+  }
 
-	/** Build bibliography label to number mapping from AST */
-	private buildBibliographyMap(elements: Element[]): void {
-		for (const el of elements) {
-			if (el.element === "bibliography-block") {
-				const data = el.data as BibliographyBlockData;
-				for (const entry of data.entries) {
-					if (!this.bibliographyMap.has(entry.key_string)) {
-						// Use continuous numbering across all bibliography blocks
-						const index = this.bibliographyMap.size + 1;
-						this.bibliographyMap.set(entry.key_string, index);
-						this.bibliographyEntries.push(entry);
-					}
-				}
-			}
-			// Recursively check nested elements
-			if ("data" in el && el.data && typeof el.data === "object") {
-				const data = el.data as Record<string, unknown>;
-				if ("elements" in data && Array.isArray(data.elements)) {
-					this.buildBibliographyMap(data.elements as Element[]);
-				}
-			}
-		}
-	}
+  /** Build bibliography label to number mapping from AST */
+  private buildBibliographyMap(elements: Element[]): void {
+    for (const el of elements) {
+      if (el.element === "bibliography-block") {
+        const data = el.data as BibliographyBlockData;
+        for (const entry of data.entries) {
+          if (!this.bibliographyMap.has(entry.key_string)) {
+            // Use continuous numbering across all bibliography blocks
+            const index = this.bibliographyMap.size + 1;
+            this.bibliographyMap.set(entry.key_string, index);
+            this.bibliographyEntries.push(entry);
+          }
+        }
+      }
+      // Recursively check nested elements
+      if ("data" in el && el.data && typeof el.data === "object") {
+        const data = el.data as Record<string, unknown>;
+        if ("elements" in data && Array.isArray(data.elements)) {
+          this.buildBibliographyMap(data.elements as Element[]);
+        }
+      }
+    }
+  }
 
-	/** Append raw HTML to the output */
-	push(html: string): void {
-		this.chunks.push(html);
-	}
+  /** Append raw HTML to the output */
+  push(html: string): void {
+    this.chunks.push(html);
+  }
 
-	/** Append escaped text to the output */
-	pushEscaped(text: string): void {
-		this.chunks.push(escapeHtml(text));
-	}
+  /** Append escaped text to the output */
+  pushEscaped(text: string): void {
+    this.chunks.push(escapeHtml(text));
+  }
 
-	/** Get the accumulated HTML output */
-	getOutput(): string {
-		return this.chunks.join("");
-	}
+  /** Get the accumulated HTML output */
+  getOutput(): string {
+    return this.chunks.join("");
+  }
 
-	/** Get and increment the TOC index */
-	nextTocIndex(): number {
-		return this._tocIndex++;
-	}
+  /** Get and increment the TOC index */
+  nextTocIndex(): number {
+    return this._tocIndex++;
+  }
 
-	/** Get and increment the footnote index */
-	nextFootnoteIndex(): number {
-		return this._footnoteIndex++;
-	}
+  /** Get and increment the footnote index */
+  nextFootnoteIndex(): number {
+    return this._footnoteIndex++;
+  }
 
-	/** Get and increment the equation index */
-	nextEquationIndex(): number {
-		return this._equationIndex++;
-	}
+  /** Get and increment the equation index */
+  nextEquationIndex(): number {
+    return this._equationIndex++;
+  }
 
-	/** Get and increment the htmlBlock index */
-	nextHtmlBlockIndex(): number {
-		return this._htmlBlockIndex++;
-	}
+  /** Get and increment the htmlBlock index */
+  nextHtmlBlockIndex(): number {
+    return this._htmlBlockIndex++;
+  }
 
-	/** Get and increment the bibcite counter (for unique IDs) */
-	nextBibciteCounter(): number {
-		return ++this._bibciteCounter;
-	}
+  /** Get and increment the bibcite counter (for unique IDs) */
+  nextBibciteCounter(): number {
+    return ++this._bibciteCounter;
+  }
 
-	/**
-	 * Generate an element ID.
-	 * When useTrueIds is true, returns `${prefix}${index}`.
-	 * When false, appends a random suffix to prevent collisions across fragments.
-	 */
-	generateId(prefix: string, index: number | string): string {
-		if (this._idSuffix === null) {
-			return `${prefix}${index}`;
-		}
-		return `${prefix}${index}-${this._idSuffix}`;
-	}
+  /**
+   * Generate an element ID.
+   * When useTrueIds is true, returns `${prefix}${index}`.
+   * When false, appends a random suffix to prevent collisions across fragments.
+   */
+  generateId(prefix: string, index: number | string): string {
+    if (this._idSuffix === null) {
+      return `${prefix}${index}`;
+    }
+    return `${prefix}${index}-${this._idSuffix}`;
+  }
 
-	/**
-	 * Generate a fixed element ID (no index).
-	 * When useTrueIds is false, appends a random suffix.
-	 */
-	generateFixedId(name: string): string {
-		if (this._idSuffix === null) {
-			return name;
-		}
-		return `${name}-${this._idSuffix}`;
-	}
+  /**
+   * Generate a fixed element ID (no index).
+   * When useTrueIds is false, appends a random suffix.
+   */
+  generateFixedId(name: string): string {
+    if (this._idSuffix === null) {
+      return name;
+    }
+    return `${name}-${this._idSuffix}`;
+  }
 
-	/** Get page context */
-	get page(): PageContext | undefined {
-		return this.options.page;
-	}
+  /** Get page context */
+  get page(): PageContext | undefined {
+    return this.options.page;
+  }
 
-	/** Resolve an ImageSource to a src URL. Returns null if blocked by settings. */
-	resolveImageSource(source: ImageSource): string | null {
-		const pageName = this.page?.pageName;
-		switch (source.type) {
-			case "url": {
-				const url = source.data;
-				// Local path (e.g., /local-file.png) — blocked when allowLocalPaths is false
-				if (url.startsWith("/") && !url.startsWith("//")) {
-					if (!this.settings.allowLocalPaths) return null;
-					return `/local--files${url}`;
-				}
-				return url;
-			}
-			case "file1":
-			case "file2":
-			case "file3":
-				if (!this.settings.allowLocalPaths) return null;
-				if (source.type === "file1") {
-					return pageName
-						? `/local--files/${pageName}/${source.data.file}`
-						: `/local--files/${source.data.file}`;
-				}
-				if (source.type === "file2") {
-					return `/local--files/${source.data.page}/${source.data.file}`;
-				}
-				return `/local--files/${source.data.site}/${source.data.page}/${source.data.file}`;
-		}
-	}
+  /** Resolve an ImageSource to a src URL. Returns null if blocked by settings. */
+  resolveImageSource(source: ImageSource): string | null {
+    const pageName = this.page?.pageName;
+    switch (source.type) {
+      case "url": {
+        const url = source.data;
+        // Local path (e.g., /local-file.png) — blocked when allowLocalPaths is false
+        if (url.startsWith("/") && !url.startsWith("//")) {
+          if (!this.settings.allowLocalPaths) return null;
+          return `/local--files${url}`;
+        }
+        return url;
+      }
+      case "file1":
+      case "file2":
+      case "file3":
+        if (!this.settings.allowLocalPaths) return null;
+        if (source.type === "file1") {
+          return pageName
+            ? `/local--files/${pageName}/${source.data.file}`
+            : `/local--files/${source.data.file}`;
+        }
+        if (source.type === "file2") {
+          return `/local--files/${source.data.page}/${source.data.file}`;
+        }
+        return `/local--files/${source.data.site}/${source.data.page}/${source.data.file}`;
+    }
+  }
 
-	/** Resolve a LinkLocation to an href string */
-	resolvePageLink(location: LinkLocation): string {
-		if (typeof location === "string") {
-			return location;
-		}
-		// PageRef - Wikidot normalizes page names
-		const page = location.page;
+  /** Resolve a LinkLocation to an href string */
+  resolvePageLink(location: LinkLocation): string {
+    if (typeof location === "string") {
+      return location;
+    }
+    // PageRef - Wikidot normalizes page names
+    const page = location.page;
 
-		// Handle special cases first
-		// //path - protocol-relative or special routing
-		if (page.startsWith("//")) {
-			return page.toLowerCase();
-		}
+    // Handle special cases first
+    // //path - protocol-relative or special routing
+    if (page.startsWith("//")) {
+      return page.toLowerCase();
+    }
 
-		// Handle # in page name (anchor routing like scp-series#001 or MAIN/#/page)
-		// The # and everything after should be preserved as-is
-		const hashIdx = page.indexOf("#");
-		if (hashIdx !== -1) {
-			let pagePart = page.slice(0, hashIdx);
-			const anchor = page.slice(hashIdx);
-			// Remove trailing slash before # (MAIN/ -> MAIN for MAIN/#/page)
-			if (pagePart.endsWith("/")) {
-				pagePart = pagePart.slice(0, -1);
-			}
-			// Don't apply slash-to-hyphen conversion for page part before #
-			return `/${pagePart.toLowerCase()}${anchor.toLowerCase()}`;
-		}
+    // Handle # in page name (anchor routing like scp-series#001 or MAIN/#/page)
+    // The # and everything after should be preserved as-is
+    const hashIdx = page.indexOf("#");
+    if (hashIdx !== -1) {
+      let pagePart = page.slice(0, hashIdx);
+      const anchor = page.slice(hashIdx);
+      // Remove trailing slash before # (MAIN/ -> MAIN for MAIN/#/page)
+      if (pagePart.endsWith("/")) {
+        pagePart = pagePart.slice(0, -1);
+      }
+      // Don't apply slash-to-hyphen conversion for page part before #
+      return `/${pagePart.toLowerCase()}${anchor.toLowerCase()}`;
+    }
 
-		const normalizedPage = this.normalizePageName(page);
-		// Remove leading slash to prevent protocol-relative URLs (//...)
-		const safePage = normalizedPage.startsWith("/")
-			? normalizedPage.slice(1)
-			: normalizedPage;
+    const normalizedPage = this.normalizePageName(page);
+    // Remove leading slash to prevent protocol-relative URLs (//...)
+    const safePage = normalizedPage.startsWith("/") ? normalizedPage.slice(1) : normalizedPage;
 
-		if (location.site) {
-			return `https://${location.site}.wikidot.com/${safePage}`;
-		}
-		return `/${safePage}`;
-	}
+    if (location.site) {
+      return `https://${location.site}.wikidot.com/${safePage}`;
+    }
+    return `/${safePage}`;
+  }
 
-	/** Normalize a page name according to Wikidot rules */
-	private normalizePageName(page: string): string {
-		// Lowercase
-		let normalized = page.toLowerCase();
-		// Remove space after category separator (system: Recent -> system:Recent)
-		normalized = normalized.replace(/:\s+/g, ":");
-		// Replace spaces with hyphens (Wikidot URL normalization)
-		normalized = normalized.replace(/\s+/g, "-").trim();
-		// Replace / with - (except at start)
-		if (!normalized.startsWith("/")) {
-			normalized = normalized.replace(/\//g, "-");
-		}
-		return normalized;
-	}
+  /** Normalize a page name according to Wikidot rules */
+  private normalizePageName(page: string): string {
+    // Lowercase
+    let normalized = page.toLowerCase();
+    // Remove space after category separator (system: Recent -> system:Recent)
+    normalized = normalized.replace(/:\s+/g, ":");
+    // Replace spaces with hyphens (Wikidot URL normalization)
+    normalized = normalized.replace(/\s+/g, "-").trim();
+    // Replace / with - (except at start)
+    if (!normalized.startsWith("/")) {
+      normalized = normalized.replace(/\//g, "-");
+    }
+    return normalized;
+  }
 
-	/** Render an AttributeMap to HTML attribute string (with leading space) */
-	renderAttributes(attributes: Record<string, string>): string {
-		const safe = sanitizeAttributes(attributes);
-		let result = "";
-		for (const [key, value] of Object.entries(safe)) {
-			if (value !== "") {
-				result += ` ${key}="${escapeAttr(value)}"`;
-			} else {
-				result += ` ${key}=""`;
-			}
-		}
-		return result;
-	}
+  /** Render an AttributeMap to HTML attribute string (with leading space) */
+  renderAttributes(attributes: Record<string, string>): string {
+    const safe = sanitizeAttributes(attributes);
+    let result = "";
+    for (const [key, value] of Object.entries(safe)) {
+      if (value !== "") {
+        result += ` ${key}="${escapeAttr(value)}"`;
+      } else {
+        result += ` ${key}=""`;
+      }
+    }
+    return result;
+  }
 }

--- a/packages/render/src/context.ts
+++ b/packages/render/src/context.ts
@@ -156,17 +156,15 @@ export class RenderContext {
         return url;
       }
       case "file1":
+        if (!this.settings.allowLocalPaths) return null;
+        return pageName
+          ? `/local--files/${pageName}/${source.data.file}`
+          : `/local--files/${source.data.file}`;
       case "file2":
+        if (!this.settings.allowLocalPaths) return null;
+        return `/local--files/${source.data.page}/${source.data.file}`;
       case "file3":
         if (!this.settings.allowLocalPaths) return null;
-        if (source.type === "file1") {
-          return pageName
-            ? `/local--files/${pageName}/${source.data.file}`
-            : `/local--files/${source.data.file}`;
-        }
-        if (source.type === "file2") {
-          return `/local--files/${source.data.page}/${source.data.file}`;
-        }
         return `/local--files/${source.data.site}/${source.data.page}/${source.data.file}`;
     }
   }

--- a/packages/render/src/context.ts
+++ b/packages/render/src/context.ts
@@ -1,11 +1,11 @@
 import type {
-  Element,
-  ImageSource,
-  LinkLocation,
-  SyntaxTree,
-  BibliographyBlockData,
-  DefinitionListItem,
-  WikitextSettings,
+	Element,
+	ImageSource,
+	LinkLocation,
+	SyntaxTree,
+	BibliographyBlockData,
+	DefinitionListItem,
+	WikitextSettings,
 } from "@wdprlib/ast";
 import { DEFAULT_SETTINGS } from "@wdprlib/ast";
 import type { RenderOptions, PageContext } from "./types";
@@ -15,228 +15,230 @@ import { escapeHtml, escapeAttr, sanitizeAttributes } from "./escape";
  * Render context - manages state and output buffer during rendering
  */
 export class RenderContext {
-  private chunks: string[] = [];
-  private _tocIndex = 0;
-  private _footnoteIndex = 0;
-  private _equationIndex = 0;
-  private _htmlBlockIndex = 0;
-  private _bibciteCounter = 0;
-  private _idSuffix: string | null;
+	private chunks: string[] = [];
+	private _tocIndex = 0;
+	private _footnoteIndex = 0;
+	private _equationIndex = 0;
+	private _htmlBlockIndex = 0;
+	private _bibciteCounter = 0;
+	private _idSuffix: string | null;
 
-  readonly settings: WikitextSettings;
-  readonly options: RenderOptions;
-  readonly footnotes: Element[][];
-  readonly styles: string[];
-  readonly htmlBlocks: string[];
-  readonly tocElements: Element[];
-  /** Map from bibliography label to citation number (1-indexed) */
-  readonly bibliographyMap: Map<string, number>;
-  /** Bibliography entries (from bibliography-block) */
-  readonly bibliographyEntries: DefinitionListItem[];
+	readonly settings: WikitextSettings;
+	readonly options: RenderOptions;
+	readonly footnotes: Element[][];
+	readonly styles: string[];
+	readonly htmlBlocks: string[];
+	readonly tocElements: Element[];
+	/** Map from bibliography label to citation number (1-indexed) */
+	readonly bibliographyMap: Map<string, number>;
+	/** Bibliography entries (from bibliography-block) */
+	readonly bibliographyEntries: DefinitionListItem[];
 
-  constructor(tree: SyntaxTree, options: RenderOptions = {}) {
-    this.settings = options.settings ?? DEFAULT_SETTINGS;
-    // When useTrueIds is false, generate a per-context random suffix for all IDs
-    this._idSuffix = this.settings.useTrueIds
-      ? null
-      : Math.random().toString(16).slice(2, 8);
-    this.options = options;
-    this.footnotes = options.footnotes ?? tree.footnotes ?? [];
-    this.styles = tree.styles ?? [];
-    this.htmlBlocks = tree["html-blocks"] ?? [];
-    this.tocElements = tree["table-of-contents"] ?? [];
+	constructor(tree: SyntaxTree, options: RenderOptions = {}) {
+		this.settings = options.settings ?? DEFAULT_SETTINGS;
+		// When useTrueIds is false, generate a per-context random suffix for all IDs
+		this._idSuffix = this.settings.useTrueIds
+			? null
+			: Math.random().toString(16).slice(2, 8);
+		this.options = options;
+		this.footnotes = options.footnotes ?? tree.footnotes ?? [];
+		this.styles = tree.styles ?? [];
+		this.htmlBlocks = tree["html-blocks"] ?? [];
+		this.tocElements = tree["table-of-contents"] ?? [];
 
-    // Build bibliography map from tree elements
-    this.bibliographyMap = new Map();
-    this.bibliographyEntries = [];
-    this.buildBibliographyMap(tree.elements);
-  }
+		// Build bibliography map from tree elements
+		this.bibliographyMap = new Map();
+		this.bibliographyEntries = [];
+		this.buildBibliographyMap(tree.elements);
+	}
 
-  /** Build bibliography label to number mapping from AST */
-  private buildBibliographyMap(elements: Element[]): void {
-    for (const el of elements) {
-      if (el.element === "bibliography-block") {
-        const data = el.data as BibliographyBlockData;
-        for (const entry of data.entries) {
-          if (!this.bibliographyMap.has(entry.key_string)) {
-            // Use continuous numbering across all bibliography blocks
-            const index = this.bibliographyMap.size + 1;
-            this.bibliographyMap.set(entry.key_string, index);
-            this.bibliographyEntries.push(entry);
-          }
-        }
-      }
-      // Recursively check nested elements
-      if ("data" in el && el.data && typeof el.data === "object") {
-        const data = el.data as Record<string, unknown>;
-        if ("elements" in data && Array.isArray(data.elements)) {
-          this.buildBibliographyMap(data.elements as Element[]);
-        }
-      }
-    }
-  }
+	/** Build bibliography label to number mapping from AST */
+	private buildBibliographyMap(elements: Element[]): void {
+		for (const el of elements) {
+			if (el.element === "bibliography-block") {
+				const data = el.data as BibliographyBlockData;
+				for (const entry of data.entries) {
+					if (!this.bibliographyMap.has(entry.key_string)) {
+						// Use continuous numbering across all bibliography blocks
+						const index = this.bibliographyMap.size + 1;
+						this.bibliographyMap.set(entry.key_string, index);
+						this.bibliographyEntries.push(entry);
+					}
+				}
+			}
+			// Recursively check nested elements
+			if ("data" in el && el.data && typeof el.data === "object") {
+				const data = el.data as Record<string, unknown>;
+				if ("elements" in data && Array.isArray(data.elements)) {
+					this.buildBibliographyMap(data.elements as Element[]);
+				}
+			}
+		}
+	}
 
-  /** Append raw HTML to the output */
-  push(html: string): void {
-    this.chunks.push(html);
-  }
+	/** Append raw HTML to the output */
+	push(html: string): void {
+		this.chunks.push(html);
+	}
 
-  /** Append escaped text to the output */
-  pushEscaped(text: string): void {
-    this.chunks.push(escapeHtml(text));
-  }
+	/** Append escaped text to the output */
+	pushEscaped(text: string): void {
+		this.chunks.push(escapeHtml(text));
+	}
 
-  /** Get the accumulated HTML output */
-  getOutput(): string {
-    return this.chunks.join("");
-  }
+	/** Get the accumulated HTML output */
+	getOutput(): string {
+		return this.chunks.join("");
+	}
 
-  /** Get and increment the TOC index */
-  nextTocIndex(): number {
-    return this._tocIndex++;
-  }
+	/** Get and increment the TOC index */
+	nextTocIndex(): number {
+		return this._tocIndex++;
+	}
 
-  /** Get and increment the footnote index */
-  nextFootnoteIndex(): number {
-    return this._footnoteIndex++;
-  }
+	/** Get and increment the footnote index */
+	nextFootnoteIndex(): number {
+		return this._footnoteIndex++;
+	}
 
-  /** Get and increment the equation index */
-  nextEquationIndex(): number {
-    return this._equationIndex++;
-  }
+	/** Get and increment the equation index */
+	nextEquationIndex(): number {
+		return this._equationIndex++;
+	}
 
-  /** Get and increment the htmlBlock index */
-  nextHtmlBlockIndex(): number {
-    return this._htmlBlockIndex++;
-  }
+	/** Get and increment the htmlBlock index */
+	nextHtmlBlockIndex(): number {
+		return this._htmlBlockIndex++;
+	}
 
-  /** Get and increment the bibcite counter (for unique IDs) */
-  nextBibciteCounter(): number {
-    return ++this._bibciteCounter;
-  }
+	/** Get and increment the bibcite counter (for unique IDs) */
+	nextBibciteCounter(): number {
+		return ++this._bibciteCounter;
+	}
 
-  /**
-   * Generate an element ID.
-   * When useTrueIds is true, returns `${prefix}${index}`.
-   * When false, appends a random suffix to prevent collisions across fragments.
-   */
-  generateId(prefix: string, index: number | string): string {
-    if (this._idSuffix === null) {
-      return `${prefix}${index}`;
-    }
-    return `${prefix}${index}-${this._idSuffix}`;
-  }
+	/**
+	 * Generate an element ID.
+	 * When useTrueIds is true, returns `${prefix}${index}`.
+	 * When false, appends a random suffix to prevent collisions across fragments.
+	 */
+	generateId(prefix: string, index: number | string): string {
+		if (this._idSuffix === null) {
+			return `${prefix}${index}`;
+		}
+		return `${prefix}${index}-${this._idSuffix}`;
+	}
 
-  /**
-   * Generate a fixed element ID (no index).
-   * When useTrueIds is false, appends a random suffix.
-   */
-  generateFixedId(name: string): string {
-    if (this._idSuffix === null) {
-      return name;
-    }
-    return `${name}-${this._idSuffix}`;
-  }
+	/**
+	 * Generate a fixed element ID (no index).
+	 * When useTrueIds is false, appends a random suffix.
+	 */
+	generateFixedId(name: string): string {
+		if (this._idSuffix === null) {
+			return name;
+		}
+		return `${name}-${this._idSuffix}`;
+	}
 
-  /** Get page context */
-  get page(): PageContext | undefined {
-    return this.options.page;
-  }
+	/** Get page context */
+	get page(): PageContext | undefined {
+		return this.options.page;
+	}
 
-  /** Resolve an ImageSource to a src URL. Returns null if blocked by settings. */
-  resolveImageSource(source: ImageSource): string | null {
-    const pageName = this.page?.pageName;
-    switch (source.type) {
-      case "url": {
-        const url = source.data;
-        // Local path (e.g., /local-file.png) — blocked when allowLocalPaths is false
-        if (url.startsWith("/") && !url.startsWith("//")) {
-          if (!this.settings.allowLocalPaths) return null;
-          return `/local--files${url}`;
-        }
-        return url;
-      }
-      case "file1":
-      case "file2":
-      case "file3":
-        if (!this.settings.allowLocalPaths) return null;
-        if (source.type === "file1") {
-          return pageName
-            ? `/local--files/${pageName}/${source.data.file}`
-            : `/local--files/${source.data.file}`;
-        }
-        if (source.type === "file2") {
-          return `/local--files/${source.data.page}/${source.data.file}`;
-        }
-        return `/local--files/${source.data.site}/${source.data.page}/${source.data.file}`;
-    }
-  }
+	/** Resolve an ImageSource to a src URL. Returns null if blocked by settings. */
+	resolveImageSource(source: ImageSource): string | null {
+		const pageName = this.page?.pageName;
+		switch (source.type) {
+			case "url": {
+				const url = source.data;
+				// Local path (e.g., /local-file.png) — blocked when allowLocalPaths is false
+				if (url.startsWith("/") && !url.startsWith("//")) {
+					if (!this.settings.allowLocalPaths) return null;
+					return `/local--files${url}`;
+				}
+				return url;
+			}
+			case "file1":
+			case "file2":
+			case "file3":
+				if (!this.settings.allowLocalPaths) return null;
+				if (source.type === "file1") {
+					return pageName
+						? `/local--files/${pageName}/${source.data.file}`
+						: `/local--files/${source.data.file}`;
+				}
+				if (source.type === "file2") {
+					return `/local--files/${source.data.page}/${source.data.file}`;
+				}
+				return `/local--files/${source.data.site}/${source.data.page}/${source.data.file}`;
+		}
+	}
 
-  /** Resolve a LinkLocation to an href string */
-  resolvePageLink(location: LinkLocation): string {
-    if (typeof location === "string") {
-      return location;
-    }
-    // PageRef - Wikidot normalizes page names
-    const page = location.page;
+	/** Resolve a LinkLocation to an href string */
+	resolvePageLink(location: LinkLocation): string {
+		if (typeof location === "string") {
+			return location;
+		}
+		// PageRef - Wikidot normalizes page names
+		const page = location.page;
 
-    // Handle special cases first
-    // //path - protocol-relative or special routing
-    if (page.startsWith("//")) {
-      return page.toLowerCase();
-    }
+		// Handle special cases first
+		// //path - protocol-relative or special routing
+		if (page.startsWith("//")) {
+			return page.toLowerCase();
+		}
 
-    // Handle # in page name (anchor routing like scp-series#001 or MAIN/#/page)
-    // The # and everything after should be preserved as-is
-    const hashIdx = page.indexOf("#");
-    if (hashIdx !== -1) {
-      let pagePart = page.slice(0, hashIdx);
-      const anchor = page.slice(hashIdx);
-      // Remove trailing slash before # (MAIN/ -> MAIN for MAIN/#/page)
-      if (pagePart.endsWith("/")) {
-        pagePart = pagePart.slice(0, -1);
-      }
-      // Don't apply slash-to-hyphen conversion for page part before #
-      return `/${pagePart.toLowerCase()}${anchor.toLowerCase()}`;
-    }
+		// Handle # in page name (anchor routing like scp-series#001 or MAIN/#/page)
+		// The # and everything after should be preserved as-is
+		const hashIdx = page.indexOf("#");
+		if (hashIdx !== -1) {
+			let pagePart = page.slice(0, hashIdx);
+			const anchor = page.slice(hashIdx);
+			// Remove trailing slash before # (MAIN/ -> MAIN for MAIN/#/page)
+			if (pagePart.endsWith("/")) {
+				pagePart = pagePart.slice(0, -1);
+			}
+			// Don't apply slash-to-hyphen conversion for page part before #
+			return `/${pagePart.toLowerCase()}${anchor.toLowerCase()}`;
+		}
 
-    const normalizedPage = this.normalizePageName(page);
-    // Remove leading slash to prevent protocol-relative URLs (//...)
-    const safePage = normalizedPage.startsWith("/") ? normalizedPage.slice(1) : normalizedPage;
+		const normalizedPage = this.normalizePageName(page);
+		// Remove leading slash to prevent protocol-relative URLs (//...)
+		const safePage = normalizedPage.startsWith("/")
+			? normalizedPage.slice(1)
+			: normalizedPage;
 
-    if (location.site) {
-      return `https://${location.site}.wikidot.com/${safePage}`;
-    }
-    return `/${safePage}`;
-  }
+		if (location.site) {
+			return `https://${location.site}.wikidot.com/${safePage}`;
+		}
+		return `/${safePage}`;
+	}
 
-  /** Normalize a page name according to Wikidot rules */
-  private normalizePageName(page: string): string {
-    // Lowercase
-    let normalized = page.toLowerCase();
-    // Remove space after category separator (system: Recent -> system:Recent)
-    normalized = normalized.replace(/:\s+/g, ":");
-    // Replace spaces with hyphens (Wikidot URL normalization)
-    normalized = normalized.replace(/\s+/g, "-").trim();
-    // Replace / with - (except at start)
-    if (!normalized.startsWith("/")) {
-      normalized = normalized.replace(/\//g, "-");
-    }
-    return normalized;
-  }
+	/** Normalize a page name according to Wikidot rules */
+	private normalizePageName(page: string): string {
+		// Lowercase
+		let normalized = page.toLowerCase();
+		// Remove space after category separator (system: Recent -> system:Recent)
+		normalized = normalized.replace(/:\s+/g, ":");
+		// Replace spaces with hyphens (Wikidot URL normalization)
+		normalized = normalized.replace(/\s+/g, "-").trim();
+		// Replace / with - (except at start)
+		if (!normalized.startsWith("/")) {
+			normalized = normalized.replace(/\//g, "-");
+		}
+		return normalized;
+	}
 
-  /** Render an AttributeMap to HTML attribute string (with leading space) */
-  renderAttributes(attributes: Record<string, string>): string {
-    const safe = sanitizeAttributes(attributes);
-    let result = "";
-    for (const [key, value] of Object.entries(safe)) {
-      if (value !== "") {
-        result += ` ${key}="${escapeAttr(value)}"`;
-      } else {
-        result += ` ${key}=""`;
-      }
-    }
-    return result;
-  }
+	/** Render an AttributeMap to HTML attribute string (with leading space) */
+	renderAttributes(attributes: Record<string, string>): string {
+		const safe = sanitizeAttributes(attributes);
+		let result = "";
+		for (const [key, value] of Object.entries(safe)) {
+			if (value !== "") {
+				result += ` ${key}="${escapeAttr(value)}"`;
+			} else {
+				result += ` ${key}=""`;
+			}
+		}
+		return result;
+	}
 }

--- a/packages/render/src/context.ts
+++ b/packages/render/src/context.ts
@@ -5,7 +5,9 @@ import type {
   SyntaxTree,
   BibliographyBlockData,
   DefinitionListItem,
+  WikitextSettings,
 } from "@wdprlib/ast";
+import { DEFAULT_SETTINGS } from "@wdprlib/ast";
 import type { RenderOptions, PageContext } from "./types";
 import { escapeHtml, escapeAttr, sanitizeAttributes } from "./escape";
 
@@ -20,6 +22,7 @@ export class RenderContext {
   private _htmlBlockIndex = 0;
   private _bibciteCounter = 0;
 
+  readonly settings: WikitextSettings;
   readonly options: RenderOptions;
   readonly footnotes: Element[][];
   readonly styles: string[];
@@ -31,6 +34,7 @@ export class RenderContext {
   readonly bibliographyEntries: DefinitionListItem[];
 
   constructor(tree: SyntaxTree, options: RenderOptions = {}) {
+    this.settings = options.settings ?? DEFAULT_SETTINGS;
     this.options = options;
     this.footnotes = options.footnotes ?? tree.footnotes ?? [];
     this.styles = tree.styles ?? [];

--- a/packages/render/src/elements/bibliography.ts
+++ b/packages/render/src/elements/bibliography.ts
@@ -33,8 +33,9 @@ export function renderBibliographyCite(ctx: RenderContext, data: BibliographyCit
   }
 
   const idSuffix = generateIdSuffix(data.label, counter);
-  const id = `bibcite-${number}-${idSuffix}`;
-  const onclick = `WIKIDOT.page.utils.scrollToReference('bibitem-${number}')`;
+  const id = ctx.generateId(`bibcite-${number}-`, idSuffix);
+  const bibitemId = ctx.generateId("bibitem-", number);
+  const onclick = `WIKIDOT.page.utils.scrollToReference('${bibitemId}')`;
 
   ctx.push(`<a href="javascript:;" class="bibcite" id="${id}" onclick="${escapeAttr(onclick)}">`);
   ctx.push(String(number));
@@ -65,7 +66,8 @@ export function renderBibliographyBlock(
 
   let index = 1;
   for (const entry of data.entries) {
-    ctx.push(`<div class="bibitem" id="bibitem-${index}">`);
+    const itemId = ctx.generateId("bibitem-", index);
+    ctx.push(`<div class="bibitem" id="${itemId}">`);
     ctx.push(`${index}. `);
     renderElements(ctx, entry.value);
     ctx.push("</div>");

--- a/packages/render/src/elements/container.ts
+++ b/packages/render/src/elements/container.ts
@@ -34,8 +34,8 @@ function renderHeader(
 ): void {
   const tag = `h${level}`;
   if (hasToc) {
-    const tocId = ctx.nextTocIndex();
-    ctx.push(`<${tag} id="toc${tocId}"${renderAttrs(attributes)}>`);
+    const tocId = ctx.generateId("toc", ctx.nextTocIndex());
+    ctx.push(`<${tag} id="${tocId}"${renderAttrs(attributes)}>`);
   } else {
     ctx.push(`<${tag}${renderAttrs(attributes)}>`);
   }

--- a/packages/render/src/elements/footnote.ts
+++ b/packages/render/src/elements/footnote.ts
@@ -5,8 +5,9 @@ import { renderElements } from "../render";
 
 /** Render a footnote reference (superscript link) */
 export function renderFootnoteRef(ctx: RenderContext, index: number): void {
+  const id = ctx.generateId("footnoteref-", index);
   ctx.push(`<sup class="footnoteref">`);
-  ctx.push(`<a id="footnoteref-${index}" href="javascript:;" class="footnoteref">${index}</a>`);
+  ctx.push(`<a id="${id}" href="javascript:;" class="footnoteref">${index}</a>`);
   ctx.push("</sup>");
 }
 
@@ -23,7 +24,8 @@ export function renderFootnoteBlock(ctx: RenderContext, data: FootnoteBlockData)
     const index = i + 1;
     const elements = ctx.footnotes[i] ?? [];
 
-    ctx.push(`<div class="footnote-footer" id="footnote-${index}">`);
+    const fnId = ctx.generateId("footnote-", index);
+    ctx.push(`<div class="footnote-footer" id="${fnId}">`);
     ctx.push(`<a href="javascript:;">${index}</a>. `);
     renderElements(ctx, elements);
     ctx.push("</div>");

--- a/packages/render/src/elements/image.ts
+++ b/packages/render/src/elements/image.ts
@@ -5,6 +5,7 @@ import { escapeAttr, isDangerousUrl, sanitizeAttributes } from "../escape";
 /** Render an image element */
 export function renderImage(ctx: RenderContext, data: ImageData): void {
   let src = ctx.resolveImageSource(data.source);
+  if (src === null) return; // Local path blocked by settings
   if (isDangerousUrl(src)) {
     src = "#invalid-url";
   }

--- a/packages/render/src/elements/math.ts
+++ b/packages/render/src/elements/math.ts
@@ -45,7 +45,9 @@ export function renderMath(ctx: RenderContext, data: MathData): void {
   const latex = data["latex-source"];
   const mathml = renderLatexToMathML(latex, true);
 
-  const id = data.name ? `equation-${data.name}` : `equation-${index}`;
+  const id = data.name
+    ? ctx.generateId("equation-", data.name)
+    : ctx.generateId("equation-", index);
   const dataName = data.name ? ` data-name="${escapeAttr(data.name)}"` : "";
 
   ctx.push(`<div class="math-block" id="${escapeAttr(id)}"${dataName}>`);
@@ -104,7 +106,7 @@ export function renderMathInline(ctx: RenderContext, data: MathInlineData): void
 
 /** Render an equation reference (link to named equation) */
 export function renderEquationRef(ctx: RenderContext, name: string): void {
-  const id = `equation-${name}`;
+  const id = ctx.generateId("equation-", name);
   ctx.push(`<span class="eref" data-target="${escapeAttr(id)}">`);
   ctx.push(`<a class="eref-link" href="#${escapeAttr(id)}">`);
   ctx.push(escapeHtml(name));

--- a/packages/render/src/elements/tab-view.ts
+++ b/packages/render/src/elements/tab-view.ts
@@ -10,7 +10,7 @@ export function renderTabView(ctx: RenderContext, tabs: TabData[]): void {
   const labelString = tabs.map((t) => t.label).join("");
   const hash = md5Hash(labelString);
 
-  const widgetId = `wiki-tabview-${hash}`;
+  const widgetId = ctx.generateFixedId(`wiki-tabview-${hash}`);
 
   // Container
   ctx.push(`<div id="${widgetId}" class="yui-navset">`);
@@ -31,7 +31,8 @@ export function renderTabView(ctx: RenderContext, tabs: TabData[]): void {
   for (let i = 0; i < tabs.length; i++) {
     const tab = tabs[i]!;
     const displayStyle = i === 0 ? "" : ` style="display:none"`;
-    ctx.push(`<div id="wiki-tab-0-${i}"${displayStyle}>`);
+    const tabId = ctx.generateId("wiki-tab-0-", i);
+    ctx.push(`<div id="${tabId}"${displayStyle}>`);
     renderElements(ctx, tab.elements);
     ctx.push("</div>");
   }

--- a/packages/render/src/elements/toc.ts
+++ b/packages/render/src/elements/toc.ts
@@ -1,6 +1,6 @@
 import type { Element, ListData, ListItem, TableOfContentsData } from "@wdprlib/ast";
 import type { RenderContext } from "../context";
-import { escapeHtml } from "../escape";
+import { escapeAttr, escapeHtml } from "../escape";
 
 /** Extract text content from a link element label */
 function extractLinkText(element: Element): { href: string; text: string } | null {
@@ -48,7 +48,7 @@ function renderTocItem(ctx: RenderContext, item: ListItem, depth: number): void 
       if (link) {
         const href = rewriteTocAnchor(ctx, link.href);
         ctx.push(
-          `<div style="margin-left: ${depth}em;"><a href="${escapeHtml(href)}">${escapeHtml(link.text)}</a></div>`,
+          `<div style="margin-left: ${depth}em;"><a href="${escapeAttr(href)}">${escapeHtml(link.text)}</a></div>`,
         );
       }
     }

--- a/packages/render/src/elements/toc.ts
+++ b/packages/render/src/elements/toc.ts
@@ -55,18 +55,22 @@ export function renderTableOfContents(ctx: RenderContext, data: TableOfContentsD
     ctx.push(`<table style="margin:0; padding:0"><tr><td style="margin:0; padding:0">`);
   }
 
+  const tocId = ctx.generateFixedId("toc");
+  const tocActionBarId = ctx.generateFixedId("toc-action-bar");
+  const tocListId = ctx.generateFixedId("toc-list");
+
   if (isFloat) {
     const floatClass = data.align === "left" ? "floatleft" : "floatright";
-    ctx.push(`<div id="toc" class="${floatClass}">`);
+    ctx.push(`<div id="${tocId}" class="${floatClass}">`);
   } else {
-    ctx.push(`<div id="toc">`);
+    ctx.push(`<div id="${tocId}">`);
   }
 
   ctx.push(
-    `<div id="toc-action-bar"><a href="javascript:;">Fold</a><a style="display: none" href="javascript:;">Unfold</a></div>`,
+    `<div id="${tocActionBarId}"><a href="javascript:;">Fold</a><a style="display: none" href="javascript:;">Unfold</a></div>`,
   );
   ctx.push(`<div class="title">Table of Contents</div>`);
-  ctx.push(`<div id="toc-list">`);
+  ctx.push(`<div id="${tocListId}">`);
   renderTocEntries(ctx, ctx.tocElements);
   ctx.push("</div>");
   ctx.push("</div>");

--- a/packages/render/src/elements/toc.ts
+++ b/packages/render/src/elements/toc.ts
@@ -30,14 +30,25 @@ function renderTocList(ctx: RenderContext, listData: ListData, depth: number): v
   }
 }
 
+/**
+ * Rewrite a TOC anchor href (e.g., "#toc0") to match the rendered heading ID.
+ * When useTrueIds is false, heading IDs have a random suffix appended.
+ */
+function rewriteTocAnchor(ctx: RenderContext, href: string): string {
+  const match = /^#toc(\d+)$/.exec(href);
+  if (!match) return href;
+  return `#${ctx.generateId("toc", Number(match[1]))}`;
+}
+
 /** Render a single TOC list item */
 function renderTocItem(ctx: RenderContext, item: ListItem, depth: number): void {
   if (item["item-type"] === "elements") {
     for (const el of item.elements) {
       const link = extractLinkText(el);
       if (link) {
+        const href = rewriteTocAnchor(ctx, link.href);
         ctx.push(
-          `<div style="margin-left: ${depth}em;"><a href="${escapeHtml(link.href)}">${escapeHtml(link.text)}</a></div>`,
+          `<div style="margin-left: ${depth}em;"><a href="${escapeHtml(href)}">${escapeHtml(link.text)}</a></div>`,
         );
       }
     }
@@ -55,22 +66,19 @@ export function renderTableOfContents(ctx: RenderContext, data: TableOfContentsD
     ctx.push(`<table style="margin:0; padding:0"><tr><td style="margin:0; padding:0">`);
   }
 
-  const tocId = ctx.generateFixedId("toc");
-  const tocActionBarId = ctx.generateFixedId("toc-action-bar");
-  const tocListId = ctx.generateFixedId("toc-list");
-
+  // TOC container IDs are fixed — the runtime queries them by ID (#toc, #toc-action-bar, #toc-list)
   if (isFloat) {
     const floatClass = data.align === "left" ? "floatleft" : "floatright";
-    ctx.push(`<div id="${tocId}" class="${floatClass}">`);
+    ctx.push(`<div id="toc" class="${floatClass}">`);
   } else {
-    ctx.push(`<div id="${tocId}">`);
+    ctx.push(`<div id="toc">`);
   }
 
   ctx.push(
-    `<div id="${tocActionBarId}"><a href="javascript:;">Fold</a><a style="display: none" href="javascript:;">Unfold</a></div>`,
+    `<div id="toc-action-bar"><a href="javascript:;">Fold</a><a style="display: none" href="javascript:;">Unfold</a></div>`,
   );
   ctx.push(`<div class="title">Table of Contents</div>`);
-  ctx.push(`<div id="${tocListId}">`);
+  ctx.push(`<div id="toc-list">`);
   renderTocEntries(ctx, ctx.tocElements);
   ctx.push("</div>");
   ctx.push("</div>");

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -1,3 +1,7 @@
 export { renderToHtml } from "./render";
 export type { RenderOptions, RenderResolvers, PageContext, ResolvedUser } from "./types";
 export { DEFAULT_EMBED_ALLOWLIST } from "./elements/embed-block";
+
+// Wikitext settings (re-exported from @wdprlib/ast)
+export type { WikitextMode, WikitextSettings } from "@wdprlib/ast";
+export { createSettings, DEFAULT_SETTINGS } from "@wdprlib/ast";

--- a/packages/render/src/render.ts
+++ b/packages/render/src/render.ts
@@ -37,7 +37,7 @@ export function renderToHtml(tree: SyntaxTree, options: RenderOptions = {}): str
   renderElements(ctx, tree.elements);
 
   // Append styles (with tag breakout prevention)
-  if (tree.styles?.length) {
+  if (ctx.settings.allowStyleElements && tree.styles?.length) {
     for (const style of tree.styles) {
       ctx.push(`<style>${escapeStyleContent(style)}</style>`);
     }

--- a/packages/render/src/types.ts
+++ b/packages/render/src/types.ts
@@ -1,4 +1,4 @@
-import type { Element } from "@wdprlib/ast";
+import type { Element, WikitextSettings } from "@wdprlib/ast";
 import type { EmbedAllowlistEntry } from "./elements/embed-block";
 
 /**
@@ -56,6 +56,8 @@ export interface RenderResolvers {
  * Options for HTML rendering
  */
 export interface RenderOptions {
+  /** Wikitext settings controlling rendering behavior */
+  settings?: WikitextSettings;
   /** Page context for resolving file paths, links, etc. */
   page?: PageContext;
   /** Pre-collected footnote elements from SyntaxTree.footnotes */

--- a/packages/runtime/src/footnote.ts
+++ b/packages/runtime/src/footnote.ts
@@ -23,7 +23,8 @@ export function initFootnote(root: HTMLElement): ModuleCleanup {
     const footnote = doc.getElementById(id);
     if (!footnote) continue;
 
-    const numId = id.replace(/^footnote-/, "");
+    // Use link text (always the clean number) for tooltip label
+    const numId = fref.textContent?.trim() ?? id.replace(/^footnote-/, "");
     const tip = buildFootnoteTooltip(doc, footnote, numId);
     container.appendChild(tip);
     tooltipMap.set(fref.id, tip);

--- a/tests/unit/parser/settings.test.ts
+++ b/tests/unit/parser/settings.test.ts
@@ -13,21 +13,21 @@ const draftSettings: WikitextSettings = createSettings("draft");
 
 describe("WikitextSettings - Parser", () => {
   describe("enablePageSyntax = true (page mode)", () => {
-    it("[[include]] はパースされる", () => {
+    it("parses [[include]]", () => {
       const doc = parse("[[include component:box]]", { settings: pageSettings });
       const elements = getContentElements(doc);
       expect(elements.length).toBe(1);
       expect(elements[0]!.element).toBe("include");
     });
 
-    it("[[module Rate]] はパースされる", () => {
+    it("parses [[module Rate]]", () => {
       const doc = parse("[[module Rate]]", { settings: pageSettings });
       const elements = getContentElements(doc);
       expect(elements.length).toBe(1);
       expect(elements[0]!.element).toBe("module");
     });
 
-    it("[[toc]] はパースされる", () => {
+    it("parses [[toc]]", () => {
       const doc = parse("[[toc]]", { settings: pageSettings });
       const elements = getContentElements(doc);
       expect(elements.length).toBe(1);
@@ -36,21 +36,21 @@ describe("WikitextSettings - Parser", () => {
   });
 
   describe("enablePageSyntax = true (draft mode)", () => {
-    it("[[include]] はパースされる", () => {
+    it("parses [[include]]", () => {
       const doc = parse("[[include component:box]]", { settings: draftSettings });
       const elements = getContentElements(doc);
       expect(elements.length).toBe(1);
       expect(elements[0]!.element).toBe("include");
     });
 
-    it("[[module Rate]] はパースされる", () => {
+    it("parses [[module Rate]]", () => {
       const doc = parse("[[module Rate]]", { settings: draftSettings });
       const elements = getContentElements(doc);
       expect(elements.length).toBe(1);
       expect(elements[0]!.element).toBe("module");
     });
 
-    it("[[toc]] はパースされる", () => {
+    it("parses [[toc]]", () => {
       const doc = parse("[[toc]]", { settings: draftSettings });
       const elements = getContentElements(doc);
       expect(elements.length).toBe(1);
@@ -59,26 +59,25 @@ describe("WikitextSettings - Parser", () => {
   });
 
   describe("enablePageSyntax = false (forum-post mode)", () => {
-    it("[[include]] はプレーンテキストになる", () => {
+    it("treats [[include]] as plain text", () => {
       const doc = parse("[[include component:box]]", { settings: forumSettings });
       const elements = getContentElements(doc);
-      // include は認識されず、パラグラフ内のテキストとして扱われる
       expect(elements.every((el) => el.element !== "include")).toBe(true);
     });
 
-    it("[[module Rate]] はプレーンテキストになる", () => {
+    it("treats [[module Rate]] as plain text", () => {
       const doc = parse("[[module Rate]]", { settings: forumSettings });
       const elements = getContentElements(doc);
       expect(elements.every((el) => el.element !== "module")).toBe(true);
     });
 
-    it("[[toc]] はプレーンテキストになる", () => {
+    it("treats [[toc]] as plain text", () => {
       const doc = parse("[[toc]]", { settings: forumSettings });
       const elements = getContentElements(doc);
       expect(elements.every((el) => el.element !== "table-of-contents")).toBe(true);
     });
 
-    it("[[f<toc]] はプレーンテキストになる", () => {
+    it("treats [[f<toc]] as plain text", () => {
       const doc = parse("[[f<toc]]", { settings: forumSettings });
       const elements = getContentElements(doc);
       expect(elements.every((el) => el.element !== "table-of-contents")).toBe(true);
@@ -86,35 +85,35 @@ describe("WikitextSettings - Parser", () => {
   });
 
   describe("enablePageSyntax = false (direct-message mode)", () => {
-    it("[[include]] はプレーンテキストになる", () => {
+    it("treats [[include]] as plain text", () => {
       const doc = parse("[[include component:box]]", { settings: dmSettings });
       const elements = getContentElements(doc);
       expect(elements.every((el) => el.element !== "include")).toBe(true);
     });
 
-    it("[[module Rate]] はプレーンテキストになる", () => {
+    it("treats [[module Rate]] as plain text", () => {
       const doc = parse("[[module Rate]]", { settings: dmSettings });
       const elements = getContentElements(doc);
       expect(elements.every((el) => el.element !== "module")).toBe(true);
     });
   });
 
-  describe("settings 未指定時のデフォルト動作", () => {
-    it("デフォルトで [[include]] がパースされる (page モード)", () => {
+  describe("default behavior (no settings specified)", () => {
+    it("parses [[include]] by default (page mode)", () => {
       const doc = parse("[[include component:box]]");
       const elements = getContentElements(doc);
       expect(elements.length).toBe(1);
       expect(elements[0]!.element).toBe("include");
     });
 
-    it("デフォルトで [[module Rate]] がパースされる", () => {
+    it("parses [[module Rate]] by default", () => {
       const doc = parse("[[module Rate]]");
       const elements = getContentElements(doc);
       expect(elements.length).toBe(1);
       expect(elements[0]!.element).toBe("module");
     });
 
-    it("デフォルトで [[toc]] がパースされる", () => {
+    it("parses [[toc]] by default", () => {
       const doc = parse("[[toc]]");
       const elements = getContentElements(doc);
       expect(elements.length).toBe(1);
@@ -122,45 +121,44 @@ describe("WikitextSettings - Parser", () => {
     });
   });
 
-  describe("resolveIncludes と settings", () => {
+  describe("resolveIncludes with settings", () => {
     const fetcher = (ref: { page: string }) => `Content of ${ref.page}`;
 
-    it("enablePageSyntax = false のとき展開をスキップする", () => {
+    it("skips expansion when enablePageSyntax = false", () => {
       const source = "Before [[include test-page]] After";
       const result = resolveIncludes(source, fetcher, { settings: forumSettings });
       expect(result).toBe(source);
     });
 
-    it("enablePageSyntax = true のとき展開される", () => {
+    it("expands when enablePageSyntax = true", () => {
       const source = "Before [[include test-page]] After";
       const result = resolveIncludes(source, fetcher, { settings: pageSettings });
       expect(result).toContain("Content of test-page");
     });
 
-    it("settings 未指定のとき展開される（後方互換）", () => {
+    it("expands when settings not specified (backward compat)", () => {
       const source = "Before [[include test-page]] After";
       const result = resolveIncludes(source, fetcher);
       expect(result).toContain("Content of test-page");
     });
   });
 
-  describe("page syntax 以外の構文は影響を受けない", () => {
-    it("forum-post モードでも太字はパースされる", () => {
+  describe("non-page syntax is unaffected", () => {
+    it("parses bold in forum-post mode", () => {
       const doc = parse("**bold text**", { settings: forumSettings });
       const elements = getContentElements(doc);
       expect(elements.length).toBe(1);
-      // パラグラフ内に bold コンテナが含まれる
       const para = elements[0]!;
       expect(para.element).toBe("container");
     });
 
-    it("forum-post モードでもリンクはパースされる", () => {
+    it("parses links in forum-post mode", () => {
       const doc = parse("[[[page-name]]]", { settings: forumSettings });
       const elements = getContentElements(doc);
       expect(elements.length).toBe(1);
     });
 
-    it("forum-post モードでもコードブロックはパースされる", () => {
+    it("parses code blocks in forum-post mode", () => {
       const doc = parse("[[code]]\nfoo\n[[/code]]", { settings: forumSettings });
       const elements = getContentElements(doc);
       expect(elements.some((el) => el.element === "code")).toBe(true);

--- a/tests/unit/parser/settings.test.ts
+++ b/tests/unit/parser/settings.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "bun:test";
+import { parse, resolveIncludes, createSettings } from "@wdprlib/parser";
+import type { Element, SyntaxTree, WikitextSettings } from "@wdprlib/ast";
+
+function getContentElements(doc: SyntaxTree): Element[] {
+  return doc.elements.filter((el) => el.element !== "footnote-block");
+}
+
+const forumSettings: WikitextSettings = createSettings("forum-post");
+const dmSettings: WikitextSettings = createSettings("direct-message");
+const pageSettings: WikitextSettings = createSettings("page");
+const draftSettings: WikitextSettings = createSettings("draft");
+
+describe("WikitextSettings - Parser", () => {
+  describe("enablePageSyntax = true (page mode)", () => {
+    it("[[include]] はパースされる", () => {
+      const doc = parse("[[include component:box]]", { settings: pageSettings });
+      const elements = getContentElements(doc);
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.element).toBe("include");
+    });
+
+    it("[[module Rate]] はパースされる", () => {
+      const doc = parse("[[module Rate]]", { settings: pageSettings });
+      const elements = getContentElements(doc);
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.element).toBe("module");
+    });
+
+    it("[[toc]] はパースされる", () => {
+      const doc = parse("[[toc]]", { settings: pageSettings });
+      const elements = getContentElements(doc);
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.element).toBe("table-of-contents");
+    });
+  });
+
+  describe("enablePageSyntax = true (draft mode)", () => {
+    it("[[include]] はパースされる", () => {
+      const doc = parse("[[include component:box]]", { settings: draftSettings });
+      const elements = getContentElements(doc);
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.element).toBe("include");
+    });
+
+    it("[[module Rate]] はパースされる", () => {
+      const doc = parse("[[module Rate]]", { settings: draftSettings });
+      const elements = getContentElements(doc);
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.element).toBe("module");
+    });
+
+    it("[[toc]] はパースされる", () => {
+      const doc = parse("[[toc]]", { settings: draftSettings });
+      const elements = getContentElements(doc);
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.element).toBe("table-of-contents");
+    });
+  });
+
+  describe("enablePageSyntax = false (forum-post mode)", () => {
+    it("[[include]] はプレーンテキストになる", () => {
+      const doc = parse("[[include component:box]]", { settings: forumSettings });
+      const elements = getContentElements(doc);
+      // include は認識されず、パラグラフ内のテキストとして扱われる
+      expect(elements.every((el) => el.element !== "include")).toBe(true);
+    });
+
+    it("[[module Rate]] はプレーンテキストになる", () => {
+      const doc = parse("[[module Rate]]", { settings: forumSettings });
+      const elements = getContentElements(doc);
+      expect(elements.every((el) => el.element !== "module")).toBe(true);
+    });
+
+    it("[[toc]] はプレーンテキストになる", () => {
+      const doc = parse("[[toc]]", { settings: forumSettings });
+      const elements = getContentElements(doc);
+      expect(elements.every((el) => el.element !== "table-of-contents")).toBe(true);
+    });
+
+    it("[[f<toc]] はプレーンテキストになる", () => {
+      const doc = parse("[[f<toc]]", { settings: forumSettings });
+      const elements = getContentElements(doc);
+      expect(elements.every((el) => el.element !== "table-of-contents")).toBe(true);
+    });
+  });
+
+  describe("enablePageSyntax = false (direct-message mode)", () => {
+    it("[[include]] はプレーンテキストになる", () => {
+      const doc = parse("[[include component:box]]", { settings: dmSettings });
+      const elements = getContentElements(doc);
+      expect(elements.every((el) => el.element !== "include")).toBe(true);
+    });
+
+    it("[[module Rate]] はプレーンテキストになる", () => {
+      const doc = parse("[[module Rate]]", { settings: dmSettings });
+      const elements = getContentElements(doc);
+      expect(elements.every((el) => el.element !== "module")).toBe(true);
+    });
+  });
+
+  describe("settings 未指定時のデフォルト動作", () => {
+    it("デフォルトで [[include]] がパースされる (page モード)", () => {
+      const doc = parse("[[include component:box]]");
+      const elements = getContentElements(doc);
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.element).toBe("include");
+    });
+
+    it("デフォルトで [[module Rate]] がパースされる", () => {
+      const doc = parse("[[module Rate]]");
+      const elements = getContentElements(doc);
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.element).toBe("module");
+    });
+
+    it("デフォルトで [[toc]] がパースされる", () => {
+      const doc = parse("[[toc]]");
+      const elements = getContentElements(doc);
+      expect(elements.length).toBe(1);
+      expect(elements[0]!.element).toBe("table-of-contents");
+    });
+  });
+
+  describe("resolveIncludes と settings", () => {
+    const fetcher = (ref: { page: string }) => `Content of ${ref.page}`;
+
+    it("enablePageSyntax = false のとき展開をスキップする", () => {
+      const source = "Before [[include test-page]] After";
+      const result = resolveIncludes(source, fetcher, { settings: forumSettings });
+      expect(result).toBe(source);
+    });
+
+    it("enablePageSyntax = true のとき展開される", () => {
+      const source = "Before [[include test-page]] After";
+      const result = resolveIncludes(source, fetcher, { settings: pageSettings });
+      expect(result).toContain("Content of test-page");
+    });
+
+    it("settings 未指定のとき展開される（後方互換）", () => {
+      const source = "Before [[include test-page]] After";
+      const result = resolveIncludes(source, fetcher);
+      expect(result).toContain("Content of test-page");
+    });
+  });
+
+  describe("page syntax 以外の構文は影響を受けない", () => {
+    it("forum-post モードでも太字はパースされる", () => {
+      const doc = parse("**bold text**", { settings: forumSettings });
+      const elements = getContentElements(doc);
+      expect(elements.length).toBe(1);
+      // パラグラフ内に bold コンテナが含まれる
+      const para = elements[0]!;
+      expect(para.element).toBe("container");
+    });
+
+    it("forum-post モードでもリンクはパースされる", () => {
+      const doc = parse("[[[page-name]]]", { settings: forumSettings });
+      const elements = getContentElements(doc);
+      expect(elements.length).toBe(1);
+    });
+
+    it("forum-post モードでもコードブロックはパースされる", () => {
+      const doc = parse("[[code]]\nfoo\n[[/code]]", { settings: forumSettings });
+      const elements = getContentElements(doc);
+      expect(elements.some((el) => el.element === "code")).toBe(true);
+    });
+  });
+});

--- a/tests/unit/render/settings.test.ts
+++ b/tests/unit/render/settings.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "bun:test";
+import { renderToHtml, createSettings } from "@wdprlib/render";
+import type { SyntaxTree, WikitextSettings } from "@wdprlib/ast";
+
+const forumSettings: WikitextSettings = createSettings("forum-post");
+const pageSettings: WikitextSettings = createSettings("page");
+const draftSettings: WikitextSettings = createSettings("draft");
+
+describe("WikitextSettings - Renderer", () => {
+  describe("allowLocalPaths = false (forum-post mode)", () => {
+    it("file1 画像がスキップされる", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "image",
+            data: {
+              source: { type: "file1", data: { file: "test.png" } },
+              attributes: {},
+              link: null,
+              alignment: null,
+            },
+          },
+        ],
+      };
+      const html = renderToHtml(tree, {
+        settings: forumSettings,
+        page: { pageName: "test-page" },
+      });
+      expect(html).not.toContain("<img");
+      expect(html).not.toContain("local--files");
+    });
+
+    it("file2 画像がスキップされる", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "image",
+            data: {
+              source: { type: "file2", data: { page: "other", file: "test.png" } },
+              attributes: {},
+              link: null,
+              alignment: null,
+            },
+          },
+        ],
+      };
+      const html = renderToHtml(tree, { settings: forumSettings });
+      expect(html).not.toContain("<img");
+    });
+
+    it("ローカルパス URL がスキップされる", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "image",
+            data: {
+              source: { type: "url", data: "/local-image.png" },
+              attributes: {},
+              link: null,
+              alignment: null,
+            },
+          },
+        ],
+      };
+      const html = renderToHtml(tree, { settings: forumSettings });
+      expect(html).not.toContain("<img");
+    });
+
+    it("外部 URL 画像は許可される", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "image",
+            data: {
+              source: { type: "url", data: "https://example.com/image.png" },
+              attributes: {},
+              link: null,
+              alignment: null,
+            },
+          },
+        ],
+      };
+      const html = renderToHtml(tree, { settings: forumSettings });
+      expect(html).toContain("<img");
+      expect(html).toContain("https://example.com/image.png");
+    });
+  });
+
+  describe("allowLocalPaths = true (page mode)", () => {
+    it("file1 画像がレンダリングされる", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "image",
+            data: {
+              source: { type: "file1", data: { file: "test.png" } },
+              attributes: {},
+              link: null,
+              alignment: null,
+            },
+          },
+        ],
+      };
+      const html = renderToHtml(tree, {
+        settings: pageSettings,
+        page: { pageName: "test-page" },
+      });
+      expect(html).toContain("<img");
+      expect(html).toContain("/local--files/test-page/test.png");
+    });
+  });
+
+  describe("useTrueIds = true (page mode)", () => {
+    it("heading ID が sequential になる", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "container",
+            data: {
+              type: { header: { level: 1, "has-toc": true } },
+              attributes: {},
+              elements: [{ element: "text", data: "Title" }],
+            },
+          },
+          {
+            element: "container",
+            data: {
+              type: { header: { level: 2, "has-toc": true } },
+              attributes: {},
+              elements: [{ element: "text", data: "Subtitle" }],
+            },
+          },
+        ],
+      };
+      const html = renderToHtml(tree, { settings: pageSettings });
+      expect(html).toContain('id="toc0"');
+      expect(html).toContain('id="toc1"');
+    });
+
+    it("TOC コンテナ ID が固定値になる", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "table-of-contents",
+            data: { attributes: {}, align: null },
+          },
+        ],
+        "table-of-contents": [],
+      };
+      const html = renderToHtml(tree, { settings: pageSettings });
+      expect(html).toContain('id="toc"');
+      expect(html).toContain('id="toc-action-bar"');
+      expect(html).toContain('id="toc-list"');
+    });
+  });
+
+  describe("useTrueIds = false (draft mode)", () => {
+    it("heading ID にランダムサフィックスが付く", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "container",
+            data: {
+              type: { header: { level: 1, "has-toc": true } },
+              attributes: {},
+              elements: [{ element: "text", data: "Title" }],
+            },
+          },
+        ],
+      };
+      const html = renderToHtml(tree, { settings: draftSettings });
+      // toc0 のあとにランダムサフィックスが付く
+      expect(html).toMatch(/id="toc0-[0-9a-f]{6}"/);
+    });
+
+    it("TOC コンテナ ID にランダムサフィックスが付く", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "table-of-contents",
+            data: { attributes: {}, align: null },
+          },
+        ],
+        "table-of-contents": [],
+      };
+      const html = renderToHtml(tree, { settings: draftSettings });
+      expect(html).toMatch(/id="toc-[0-9a-f]{6}"/);
+      expect(html).toMatch(/id="toc-action-bar-[0-9a-f]{6}"/);
+      expect(html).toMatch(/id="toc-list-[0-9a-f]{6}"/);
+    });
+
+    it("footnote ID にランダムサフィックスが付く", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "footnote-block",
+            data: { title: null, hide: false },
+          },
+        ],
+        footnotes: [[{ element: "text", data: "A note" }]],
+      };
+      const html = renderToHtml(tree, { settings: draftSettings });
+      expect(html).toMatch(/id="footnote-1-[0-9a-f]{6}"/);
+    });
+  });
+
+  describe("settings 未指定時のデフォルト動作", () => {
+    it("デフォルトで file1 画像がレンダリングされる (page モード)", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "image",
+            data: {
+              source: { type: "file1", data: { file: "test.png" } },
+              attributes: {},
+              link: null,
+              alignment: null,
+            },
+          },
+        ],
+      };
+      const html = renderToHtml(tree, { page: { pageName: "test-page" } });
+      expect(html).toContain("<img");
+      expect(html).toContain("/local--files/test-page/test.png");
+    });
+
+    it("デフォルトで heading ID が sequential になる", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "container",
+            data: {
+              type: { header: { level: 1, "has-toc": true } },
+              attributes: {},
+              elements: [{ element: "text", data: "Title" }],
+            },
+          },
+        ],
+      };
+      const html = renderToHtml(tree);
+      expect(html).toContain('id="toc0"');
+    });
+  });
+});

--- a/tests/unit/render/settings.test.ts
+++ b/tests/unit/render/settings.test.ts
@@ -8,7 +8,7 @@ const draftSettings: WikitextSettings = createSettings("draft");
 
 describe("WikitextSettings - Renderer", () => {
   describe("allowLocalPaths = false (forum-post mode)", () => {
-    it("file1 画像がスキップされる", () => {
+    it("skips file1 images", () => {
       const tree: SyntaxTree = {
         elements: [
           {
@@ -30,7 +30,7 @@ describe("WikitextSettings - Renderer", () => {
       expect(html).not.toContain("local--files");
     });
 
-    it("file2 画像がスキップされる", () => {
+    it("skips file2 images", () => {
       const tree: SyntaxTree = {
         elements: [
           {
@@ -48,7 +48,7 @@ describe("WikitextSettings - Renderer", () => {
       expect(html).not.toContain("<img");
     });
 
-    it("ローカルパス URL がスキップされる", () => {
+    it("skips local path URLs", () => {
       const tree: SyntaxTree = {
         elements: [
           {
@@ -66,7 +66,7 @@ describe("WikitextSettings - Renderer", () => {
       expect(html).not.toContain("<img");
     });
 
-    it("外部 URL 画像は許可される", () => {
+    it("allows external URL images", () => {
       const tree: SyntaxTree = {
         elements: [
           {
@@ -87,7 +87,7 @@ describe("WikitextSettings - Renderer", () => {
   });
 
   describe("allowLocalPaths = true (page mode)", () => {
-    it("file1 画像がレンダリングされる", () => {
+    it("renders file1 images", () => {
       const tree: SyntaxTree = {
         elements: [
           {
@@ -111,7 +111,7 @@ describe("WikitextSettings - Renderer", () => {
   });
 
   describe("useTrueIds = true (page mode)", () => {
-    it("heading ID が sequential になる", () => {
+    it("generates sequential heading IDs", () => {
       const tree: SyntaxTree = {
         elements: [
           {
@@ -137,7 +137,7 @@ describe("WikitextSettings - Renderer", () => {
       expect(html).toContain('id="toc1"');
     });
 
-    it("TOC コンテナ ID が固定値になる", () => {
+    it("generates fixed TOC container IDs", () => {
       const tree: SyntaxTree = {
         elements: [
           {
@@ -155,7 +155,7 @@ describe("WikitextSettings - Renderer", () => {
   });
 
   describe("useTrueIds = false (draft mode)", () => {
-    it("heading ID にランダムサフィックスが付く", () => {
+    it("appends random suffix to heading IDs", () => {
       const tree: SyntaxTree = {
         elements: [
           {
@@ -169,11 +169,10 @@ describe("WikitextSettings - Renderer", () => {
         ],
       };
       const html = renderToHtml(tree, { settings: draftSettings });
-      // toc0 のあとにランダムサフィックスが付く
       expect(html).toMatch(/id="toc0-[0-9a-f]{6}"/);
     });
 
-    it("TOC コンテナ ID は固定値のまま (runtime 互換)", () => {
+    it("keeps TOC container IDs fixed (runtime compat)", () => {
       const tree: SyntaxTree = {
         elements: [
           {
@@ -189,7 +188,7 @@ describe("WikitextSettings - Renderer", () => {
       expect(html).toContain('id="toc-list"');
     });
 
-    it("footnote ID にランダムサフィックスが付く", () => {
+    it("appends random suffix to footnote IDs", () => {
       const tree: SyntaxTree = {
         elements: [
           {
@@ -205,7 +204,7 @@ describe("WikitextSettings - Renderer", () => {
   });
 
   describe("allowStyleElements = false (draft mode)", () => {
-    it("style が出力されない", () => {
+    it("suppresses style output", () => {
       const tree: SyntaxTree = {
         elements: [],
         styles: ["body { color: red; }"],
@@ -215,7 +214,7 @@ describe("WikitextSettings - Renderer", () => {
       expect(html).not.toContain("body { color: red; }");
     });
 
-    it("forum-post モードでも style が出力されない", () => {
+    it("suppresses style output in forum-post mode", () => {
       const tree: SyntaxTree = {
         elements: [],
         styles: [".custom { display: none; }"],
@@ -226,7 +225,7 @@ describe("WikitextSettings - Renderer", () => {
   });
 
   describe("allowStyleElements = true (page mode)", () => {
-    it("style が出力される", () => {
+    it("outputs style elements", () => {
       const tree: SyntaxTree = {
         elements: [],
         styles: ["body { color: red; }"],
@@ -237,8 +236,8 @@ describe("WikitextSettings - Renderer", () => {
     });
   });
 
-  describe("settings 未指定時のデフォルト動作", () => {
-    it("デフォルトで file1 画像がレンダリングされる (page モード)", () => {
+  describe("default behavior (no settings specified)", () => {
+    it("renders file1 images by default (page mode)", () => {
       const tree: SyntaxTree = {
         elements: [
           {
@@ -257,7 +256,7 @@ describe("WikitextSettings - Renderer", () => {
       expect(html).toContain("/local--files/test-page/test.png");
     });
 
-    it("デフォルトで style が出力される (page モード)", () => {
+    it("outputs style elements by default (page mode)", () => {
       const tree: SyntaxTree = {
         elements: [],
         styles: ["body { color: red; }"],
@@ -267,7 +266,7 @@ describe("WikitextSettings - Renderer", () => {
       expect(html).toContain("body { color: red; }");
     });
 
-    it("デフォルトで heading ID が sequential になる", () => {
+    it("generates sequential heading IDs by default", () => {
       const tree: SyntaxTree = {
         elements: [
           {

--- a/tests/unit/render/settings.test.ts
+++ b/tests/unit/render/settings.test.ts
@@ -204,6 +204,39 @@ describe("WikitextSettings - Renderer", () => {
     });
   });
 
+  describe("allowStyleElements = false (draft mode)", () => {
+    it("style が出力されない", () => {
+      const tree: SyntaxTree = {
+        elements: [],
+        styles: ["body { color: red; }"],
+      };
+      const html = renderToHtml(tree, { settings: draftSettings });
+      expect(html).not.toContain("<style>");
+      expect(html).not.toContain("body { color: red; }");
+    });
+
+    it("forum-post モードでも style が出力されない", () => {
+      const tree: SyntaxTree = {
+        elements: [],
+        styles: [".custom { display: none; }"],
+      };
+      const html = renderToHtml(tree, { settings: forumSettings });
+      expect(html).not.toContain("<style>");
+    });
+  });
+
+  describe("allowStyleElements = true (page mode)", () => {
+    it("style が出力される", () => {
+      const tree: SyntaxTree = {
+        elements: [],
+        styles: ["body { color: red; }"],
+      };
+      const html = renderToHtml(tree, { settings: pageSettings });
+      expect(html).toContain("<style>");
+      expect(html).toContain("body { color: red; }");
+    });
+  });
+
   describe("settings 未指定時のデフォルト動作", () => {
     it("デフォルトで file1 画像がレンダリングされる (page モード)", () => {
       const tree: SyntaxTree = {
@@ -222,6 +255,16 @@ describe("WikitextSettings - Renderer", () => {
       const html = renderToHtml(tree, { page: { pageName: "test-page" } });
       expect(html).toContain("<img");
       expect(html).toContain("/local--files/test-page/test.png");
+    });
+
+    it("デフォルトで style が出力される (page モード)", () => {
+      const tree: SyntaxTree = {
+        elements: [],
+        styles: ["body { color: red; }"],
+      };
+      const html = renderToHtml(tree);
+      expect(html).toContain("<style>");
+      expect(html).toContain("body { color: red; }");
     });
 
     it("デフォルトで heading ID が sequential になる", () => {

--- a/tests/unit/render/settings.test.ts
+++ b/tests/unit/render/settings.test.ts
@@ -173,7 +173,7 @@ describe("WikitextSettings - Renderer", () => {
       expect(html).toMatch(/id="toc0-[0-9a-f]{6}"/);
     });
 
-    it("TOC コンテナ ID にランダムサフィックスが付く", () => {
+    it("TOC コンテナ ID は固定値のまま (runtime 互換)", () => {
       const tree: SyntaxTree = {
         elements: [
           {
@@ -184,9 +184,9 @@ describe("WikitextSettings - Renderer", () => {
         "table-of-contents": [],
       };
       const html = renderToHtml(tree, { settings: draftSettings });
-      expect(html).toMatch(/id="toc-[0-9a-f]{6}"/);
-      expect(html).toMatch(/id="toc-action-bar-[0-9a-f]{6}"/);
-      expect(html).toMatch(/id="toc-list-[0-9a-f]{6}"/);
+      expect(html).toContain('id="toc"');
+      expect(html).toContain('id="toc-action-bar"');
+      expect(html).toContain('id="toc-list"');
     });
 
     it("footnote ID にランダムサフィックスが付く", () => {


### PR DESCRIPTION
## Summary

ftml の WikitextMode / WikitextSettings パターンを wdpr に導入し、コンテキスト（ページ、ドラフト、フォーラム投稿、DM）に応じてパーサーとレンダラーの振る舞いを制御できるようにした。

- `ast` パッケージに `WikitextMode` / `WikitextSettings` 型と `createSettings()` ファクトリ関数を追加
- パーサーに `enablePageSyntax` チェックを追加（`[[include]]`, `[[module]]`, `[[toc]]` をモードに応じて無効化）
- レンダラーに `allowLocalPaths`（ローカルファイル画像のブロック）、`useTrueIds`（ID のランダム化）、`allowStyleElements`（`[[module CSS]]` の出力制御）を追加
- runtime の footnote tooltip が randomized ID でも正しい番号を表示するよう修正

## Changes

### 新規ファイル
- `packages/ast/src/settings.ts` — WikitextMode, WikitextSettings 型定義、createSettings(), DEFAULT_SETTINGS
- `tests/unit/parser/settings.test.ts` — パーサー設定テスト（17件）
- `tests/unit/render/settings.test.ts` — レンダラー設定テスト（16件）+ allowStyleElements テスト（4件）

### 変更ファイル
- `packages/parser` — ParseContext / ParserOptions に settings を追加、include / module / toc に enablePageSyntax ゲート追加
- `packages/render` — RenderContext に settings / generateId / generateFixedId を追加、画像・TOC・footnote・bibliography・tab-view・math の ID 生成を対応、allowStyleElements チェック追加
- `packages/runtime` — footnote tooltip のラベル表示を ID 解析からリンクテキストに変更

### モード設定マトリクス

| Mode | enablePageSyntax | allowLocalPaths | useTrueIds | allowStyleElements |
|------|:---:|:---:|:---:|:---:|
| page | true | true | true | true |
| draft | true | true | false | false |
| forum-post | false | false | false | false |
| direct-message | false | false | false | false |

## Test plan

- [x] 既存テスト全パス（973 pass, 0 fail）
- [x] 新規設定テスト全パス（37件）
- [x] lint / format / typecheck パス