### PR TITLE
feat(render): embed-blockでプロトコル相対URLとHTTPスキームを対応

### DIFF
--- a/examples/wdmock-cf/apps/main/src/services/pipeline.ts
+++ b/examples/wdmock-cf/apps/main/src/services/pipeline.ts
@@ -102,6 +102,7 @@ export async function renderPage(
       user: (username) => ({ name: username }),
     },
     htmlBlockSandbox: null,
+    embedAllowlist: null,
   });
 
   return { html, styles };

--- a/packages/render/src/elements/embed-block.ts
+++ b/packages/render/src/elements/embed-block.ts
@@ -88,7 +88,7 @@ const SANITIZE_CONFIG: sanitizeHtml.IOptions = {
       "width",
     ],
   },
-  allowedSchemes: ["https"],
+  allowedSchemes: ["https", "http"],
 };
 
 /**
@@ -170,6 +170,7 @@ function matchesAllowlistEntry(url: URL, entry: EmbedAllowlistEntry): boolean {
 function validateAndSanitizeEmbed(
   content: string,
   allowlist: EmbedAllowlistEntry[] | null,
+  baseUrl?: string,
 ): string | null {
   // Sanitize with sanitize-html to remove dangerous content
   const sanitized = sanitizeHtml(content.trim(), SANITIZE_CONFIG);
@@ -192,20 +193,26 @@ function validateAndSanitizeEmbed(
     return null;
   }
 
-  // Parse URL
+  // Parse URL (protocol-relative URLs are resolved against baseUrl)
   let url: URL;
   try {
-    url = new URL(src);
+    if (src.startsWith("//")) {
+      // Protocol-relative URL: resolve against baseUrl, defaulting to https:
+      const base = baseUrl ?? "https://localhost";
+      url = new URL(src, base);
+    } else {
+      url = new URL(src);
+    }
   } catch {
     return null;
   }
 
-  // Only allow HTTPS
-  if (url.protocol !== "https:") {
+  // Only allow HTTP and HTTPS
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
     return null;
   }
 
-  // If allowlist is null, allow any HTTPS iframe (Wikidot's 'anyiframe' behavior)
+  // If allowlist is null, allow any HTTP(S) iframe (Wikidot's 'anyiframe' behavior)
   if (allowlist !== null) {
     // Check if URL matches any allowlist entry
     const matched = allowlist.some((entry) => matchesAllowlistEntry(url, entry));
@@ -248,7 +255,7 @@ export function renderEmbedBlock(ctx: RenderContext, data: EmbedBlockData): void
   const allowlist =
     ctx.options.embedAllowlist !== undefined ? ctx.options.embedAllowlist : DEFAULT_EMBED_ALLOWLIST;
 
-  const sanitized = validateAndSanitizeEmbed(data.contents, allowlist);
+  const sanitized = validateAndSanitizeEmbed(data.contents, allowlist, ctx.options.baseUrl);
   if (sanitized === null) {
     ctx.push('<div class="error-block">Sorry, no match for the embedded content.</div>');
     return;

--- a/packages/render/src/types.ts
+++ b/packages/render/src/types.ts
@@ -56,6 +56,13 @@ export interface RenderResolvers {
  * Options for HTML rendering
  */
 export interface RenderOptions {
+  /**
+   * Base URL used to resolve protocol-relative URLs (e.g., "//example.com/path").
+   * The protocol of this URL is inherited by protocol-relative references.
+   * Example: "https://scp-wiki.wikidot.com" or "http://scp-jp.wikidot.com"
+   * If not provided, protocol-relative URLs default to HTTPS.
+   */
+  baseUrl?: string;
   /** Page context for resolving file paths, links, etc. */
   page?: PageContext;
   /** Pre-collected footnote elements from SyntaxTree.footnotes */

--- a/tests/unit/render/embed-block.test.ts
+++ b/tests/unit/render/embed-block.test.ts
@@ -159,13 +159,13 @@ describe("embed-block security", () => {
   });
 
   describe("blocked content", () => {
-    test("Non-HTTPS is blocked", () => {
+    test("HTTP iframe is allowed for allowlisted host", () => {
       const ctx = createMockContext();
       const data = {
         contents: '<iframe src="http://www.youtube.com/embed/dQw4w9WgXcQ"></iframe>',
       };
       renderEmbedBlock(ctx, data);
-      expect(ctx.getOutput()).toContain("error-block");
+      expect(ctx.getOutput()).not.toContain("error-block");
     });
 
     test("Unknown host is blocked", () => {
@@ -235,13 +235,13 @@ describe("embed-block security", () => {
       expect(ctx.getOutput()).not.toContain("error-block");
     });
 
-    test("HTTP is still blocked when allowlist is null", () => {
+    test("HTTP is allowed when allowlist is null", () => {
       const ctx = createMockContext({ embedAllowlist: null });
       const data = {
         contents: '<iframe src="http://any-site.example.com/embed"></iframe>',
       };
       renderEmbedBlock(ctx, data);
-      expect(ctx.getOutput()).toContain("error-block");
+      expect(ctx.getOutput()).not.toContain("error-block");
     });
 
     test("Multiple iframes are still blocked when allowlist is null", () => {
@@ -251,6 +251,57 @@ describe("embed-block security", () => {
       };
       renderEmbedBlock(ctx, data);
       expect(ctx.getOutput()).toContain("error-block");
+    });
+  });
+
+  describe("protocol-relative URLs", () => {
+    test("protocol-relative URL is resolved with HTTPS baseUrl", () => {
+      const ctx = createMockContext({
+        embedAllowlist: null,
+        baseUrl: "https://scp-wiki.wikidot.com",
+      });
+      const data = {
+        contents: '<iframe src="//interwiki.scp-jp.org/interwikiFrame.html"></iframe>',
+      };
+      renderEmbedBlock(ctx, data);
+      expect(ctx.getOutput()).not.toContain("error-block");
+    });
+
+    test("protocol-relative URL is resolved with HTTP baseUrl", () => {
+      const ctx = createMockContext({ embedAllowlist: null, baseUrl: "http://scp-jp.wikidot.com" });
+      const data = {
+        contents: '<iframe src="//interwiki.scp-jp.org/interwikiFrame.html"></iframe>',
+      };
+      renderEmbedBlock(ctx, data);
+      expect(ctx.getOutput()).not.toContain("error-block");
+    });
+
+    test("protocol-relative URL defaults to HTTPS when baseUrl is not provided", () => {
+      const ctx = createMockContext({ embedAllowlist: null });
+      const data = {
+        contents: '<iframe src="//interwiki.scp-jp.org/interwikiFrame.html"></iframe>',
+      };
+      renderEmbedBlock(ctx, data);
+      expect(ctx.getOutput()).not.toContain("error-block");
+    });
+
+    test("protocol-relative URL is checked against allowlist", () => {
+      const ctx = createMockContext({ baseUrl: "https://example.com" });
+      const data = {
+        contents: '<iframe src="//unknown-host.example.com/page"></iframe>',
+      };
+      renderEmbedBlock(ctx, data);
+      expect(ctx.getOutput()).toContain("error-block");
+    });
+
+    test("protocol-relative URL with allowlisted host is allowed", () => {
+      const allowlist = [{ host: "*.youtube.com", pathPrefix: "/embed/" }];
+      const ctx = createMockContext({ embedAllowlist: allowlist, baseUrl: "https://example.com" });
+      const data = {
+        contents: '<iframe src="//www.youtube.com/embed/abc123"></iframe>',
+      };
+      renderEmbedBlock(ctx, data);
+      expect(ctx.getOutput()).not.toContain("error-block");
     });
   });
 


### PR DESCRIPTION
## Summary
- `RenderOptions`に`baseUrl`を追加し、プロトコル相対URL（`//example.com/...`）を`baseUrl`のプロトコルで解決するように変更
- `allowedSchemes`に`http`を追加し、HTTPで配信されるサイトでもembed-blockが動作するように
- `examples/wdmock-cf`で`embedAllowlist: null`を設定（全ドメイン許可）

## Background
SCP WikiのinterwikiコンポーネントがHTTPで配信されるケースがあり、プロトコル相対URL（`//interwiki.scp-jp.org/...`）がembed-blockのバリデーションで拒否されていた。

## Changes
- `packages/render/src/types.ts`: `RenderOptions`に`baseUrl`フィールド追加
- `packages/render/src/elements/embed-block.ts`: プロトコル相対URL対応、HTTP許可
- `examples/wdmock-cf/apps/main/src/services/pipeline.ts`: `embedAllowlist: null`追加
- `tests/unit/render/embed-block.test.ts`: プロトコル相対URLテスト5件追加、既存テスト2件更新

## Test plan
- [x] `bun test` 全941テスト通過
- [x] `bun run typecheck` 通過
- [x] `bun run lint` 新規警告なし
- [x] プロトコル相対URLがHTTPS/HTTP baseUrlで正しく解決されること
- [x] baseUrl未指定時にHTTPSにフォールバックすること