### PR TITLE
fix: polynomial ReDoSの正規表現パターンを修正

### DIFF
--- a/packages/parser/src/parser/rules/block/module/include/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/include/resolve.ts
@@ -75,8 +75,8 @@ export function resolveIncludes(
  * Regex to match [[include ...]] directives.
  * Captures the content between [[include and ]] (may span multiple lines).
  */
-// Avoid [\s\S]*? which causes polynomial backtracking (CodeQL #20)
-const INCLUDE_PATTERN = /\[\[include\s+([^\]]*(?:\](?!\])[^\]]*)*)\]\]/gi;
+// \s (single char, no quantifier) avoids overlap with [^\]]* that causes polynomial backtracking
+const INCLUDE_PATTERN = /\[\[include\s([^\]]*(?:\](?!\])[^\]]*)*)\]\]/gi;
 
 /**
  * Parse an include directive's inner content into page reference and variables.

--- a/packages/parser/src/parser/rules/block/module/include/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/include/resolve.ts
@@ -75,7 +75,8 @@ export function resolveIncludes(
  * Regex to match [[include ...]] directives.
  * Captures the content between [[include and ]] (may span multiple lines).
  */
-const INCLUDE_PATTERN = /\[\[include\s+([\s\S]*?)\]\]/gi;
+// Avoid [\s\S]*? which causes polynomial backtracking (CodeQL #20)
+const INCLUDE_PATTERN = /\[\[include\s+([^\]]*(?:\](?!\])[^\]]*)*)\]\]/gi;
 
 /**
  * Parse an include directive's inner content into page reference and variables.

--- a/packages/render/src/escape.ts
+++ b/packages/render/src/escape.ts
@@ -331,16 +331,21 @@ export function isValidCssColor(color: string): boolean {
     return true;
   }
 
-  // rgb() / rgba() - strict pattern to prevent injection
-  if (/^rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*(,\s*(0|1|0?\.\d+))?\s*\)$/.test(trimmed)) {
-    return true;
-  }
-
-  // hsl() / hsla() - strict pattern to prevent injection
-  if (
-    /^hsla?\(\s*\d{1,3}\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%\s*(,\s*(0|1|0?\.\d+))?\s*\)$/.test(trimmed)
-  ) {
-    return true;
+  // Extract function name and args separately to avoid ReDoS from repeated \s* quantifiers.
+  // Only strip whitespace from args, keeping function name validation strict.
+  const fnMatch = trimmed.match(/^(rgba?|hsla?)\(([^)]*)\)$/);
+  if (fnMatch) {
+    const fn = fnMatch[1]!;
+    // Only trim whitespace around commas (structural delimiters), not within tokens
+    const args = fnMatch[2]!
+      .split(",")
+      .map((s) => s.trim())
+      .join(",");
+    if (fn.startsWith("rgb")) {
+      if (/^\d{1,3},\d{1,3},\d{1,3}(,(0|1|0?\.\d+))?$/.test(args)) return true;
+    } else {
+      if (/^\d{1,3},\d{1,3}%,\d{1,3}%(,(0|1|0?\.\d+))?$/.test(args)) return true;
+    }
   }
 
   // Reject everything else (including semicolons, url(), expression(), etc.)


### PR DESCRIPTION
## Summary
 - CodeQL code scanning で検出された Polynomial ReDoS (js/polynomial-redos) の残存3件を修正
   - #23: `escape.ts` rgb/rgba色検証の `\s*` 連続パターン
   - #24: `escape.ts` hsl/hsla色検証の `\s*` 連続パターン
   - #20: `resolve.ts` INCLUDE_PATTERNの `[\s\S]*?` パターン

 ## Changes

 ### `packages/render/src/escape.ts`
 `isValidCssColor` の rgb/rgba, hsl/hsla 検証で、`\s*` を繰り返す正規表現を廃止。関数名と引数を
 `^(rgba?|hsla?)\(([^)]*)\)$` で分離し、引数はカンマでsplit → trim →
 joinすることで構造区切り周辺のみ正規化。引数パターンからホワイトスペース量指定子を排除した。

 ### `packages/parser/src/parser/rules/block/module/include/resolve.ts`
 `INCLUDE_PATTERN` の `[\s\S]*?`（lazy wildcard）を `[^\]]*(?:\](?!\])[^\]]*)*`
 に置換。各文字を一度だけ消費する線形パターンで、`]]` 未出現時のバックトラッキングを防止。

 ## Test plan
 - [x] 既存テスト全978件パス
 - [x] typecheck / lint / format OK
 - [ ] CodeQL code scanning で #20, #23, #24 が解消されていることを確認