### PR TITLE
feat: llms.txt + Markdown ドキュメント生成を追加

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,9 +5,13 @@ on:
     branches: [develop]
     paths:
       - "packages/*/src/**"
+      - "packages/*/README.md"
+      - "README.md"
       - "typedoc.json"
+      - "typedoc.llms.json"
       - "packages/*/typedoc.json"
       - "packages/*/tsconfig.typedoc.json"
+      - "scripts/build-llms.ts"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -32,7 +36,7 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      - run: bun run docs
+      - run: bun run docs:all
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,8 @@
         "oxfmt": "^0.27.0",
         "oxlint": "^1.42.0",
         "typedoc": "^0.28.16",
+        "typedoc-plugin-llms-txt": "^0.1.2",
+        "typedoc-plugin-markdown": "^4.10.0",
         "typescript": "^5.9.3",
       },
     },
@@ -1231,6 +1233,10 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typedoc": ["typedoc@0.28.16", "", { "dependencies": { "@gerrit0/mini-shiki": "^3.17.0", "lunr": "^2.3.9", "markdown-it": "^14.1.0", "minimatch": "^9.0.5", "yaml": "^2.8.1" }, "peerDependencies": { "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x" }, "bin": { "typedoc": "bin/typedoc" } }, "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog=="],
+
+    "typedoc-plugin-llms-txt": ["typedoc-plugin-llms-txt@0.1.2", "", { "peerDependencies": { "typedoc": "^0.28.0" } }, "sha512-9q7x5ZdwkSZKJK23cvirtfQw87970n2p/hSv3T0YlOlgIY6isRHdUOM+QPErANFPXZv0X+ezS6QZp10dejOExQ=="],
+
+    "typedoc-plugin-markdown": ["typedoc-plugin-markdown@4.10.0", "", { "peerDependencies": { "typedoc": "0.28.x" } }, "sha512-psrg8Rtnv4HPWCsoxId+MzEN8TVK5jeKCnTbnGAbTBqcDapR9hM41bJT/9eAyKn9C2MDG9Qjh3MkltAYuLDoXg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "release": "nx release",
     "release:dry-run": "nx release --dry-run",
     "docs": "typedoc",
-    "docs:watch": "typedoc --watch"
+    "docs:watch": "typedoc --watch",
+    "docs:llms": "typedoc --options typedoc.llms.json && bun scripts/build-llms.ts",
+    "docs:all": "bun run docs && bun run docs:llms"
   },
   "devDependencies": {
     "@nx/js": "^22.4.5",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "oxfmt": "^0.27.0",
     "oxlint": "^1.42.0",
     "typedoc": "^0.28.16",
+    "typedoc-plugin-llms-txt": "^0.1.2",
+    "typedoc-plugin-markdown": "^4.10.0",
     "typescript": "^5.9.3"
   },
   "trustedDependencies": [

--- a/packages/render/src/elements/expr.ts
+++ b/packages/render/src/elements/expr.ts
@@ -2,10 +2,10 @@
  *
  * Renderers for Wikidot's expression and conditional constructs:
  *
- * - `[[# expr EXPRESSION]]` -- evaluate a mathematical expression and
+ * - `[[#expr EXPRESSION]]` -- evaluate a mathematical expression and
  *   display the numeric result.
- * - `[[# if VALUE | THEN | ELSE]]` -- simple string-based truthiness check.
- * - `[[# ifexpr EXPRESSION | THEN | ELSE]]` -- evaluate a math expression
+ * - `[[#if VALUE | THEN | ELSE]]` -- simple string-based truthiness check.
+ * - `[[#ifexpr EXPRESSION | THEN | ELSE]]` -- evaluate a math expression
  *   and branch on the numeric result (0 = false, non-zero = true).
  *
  * All error messages match Wikidot's format (`"run-time error: ..."`).
@@ -19,7 +19,7 @@ import { renderElements } from "../render";
 import { evaluateExpression, isTruthy } from "../utils/expr-eval";
 
 /**
- * Render a `[[# expr]]` element.
+ * Render a `[[#expr]]` element.
  *
  * Evaluates the mathematical expression and outputs the formatted numeric
  * result. On evaluation error, a Wikidot-compatible error message is
@@ -39,7 +39,7 @@ export function renderExpr(ctx: RenderContext, data: ExprData): void {
 }
 
 /**
- * Render a `[[# if]]` conditional element.
+ * Render a `[[#if]]` conditional element.
  *
  * The condition is treated as a string: values `"false"`, `"null"`,
  * `""`, and `"0"` are falsy; everything else is truthy. The selected
@@ -54,7 +54,7 @@ export function renderIf(ctx: RenderContext, data: IfCondData): void {
 }
 
 /**
- * Render a `[[# ifexpr]]` conditional expression element.
+ * Render a `[[#ifexpr]]` conditional expression element.
  *
  * Evaluates the mathematical expression; a result of 0 selects the
  * `else` branch, any non-zero result selects the `then` branch.

--- a/scripts/build-llms.ts
+++ b/scripts/build-llms.ts
@@ -1,0 +1,96 @@
+/**
+ * llms.txt 後処理スクリプト
+ *
+ * typedoc-plugin-llms-txt が docs/llms/ 内に生成した llms.txt を
+ * docs/ ルートに移動し、リンクパスを調整する。
+ * 併せて全 Markdown を結合した llms-full.txt を生成する。
+ *
+ * Usage: bun scripts/build-llms.ts
+ */
+
+import { readdir, stat } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const DOCS_DIR = "docs";
+const LLMS_DIR = join(DOCS_DIR, "llms");
+const LLMS_TXT_SRC = join(LLMS_DIR, "llms.txt");
+const LLMS_TXT_DEST = join(DOCS_DIR, "llms.txt");
+const LLMS_FULL_DEST = join(DOCS_DIR, "llms-full.txt");
+
+// Markdown リンク [text](path) のうちローカル相対パスのみ変換する正規表現
+// http/https/mailto/tel/#anchor は除外
+const MD_LINK_RE = /\]\((?!https?:\/\/|#|mailto:|tel:)([^)]+)\)/g;
+
+async function collectMdFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectMdFiles(fullPath)));
+    } else if (entry.name.endsWith(".md")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+async function main() {
+  // 1. llms.txt の読み込みと検証
+  if (!existsSync(LLMS_TXT_SRC)) {
+    console.error(`Error: ${LLMS_TXT_SRC} not found. Run typedoc --options typedoc.llms.json first.`);
+    process.exit(1);
+  }
+
+  const llmsTxt = await Bun.file(LLMS_TXT_SRC).text();
+
+  // 2. 相対パスに llms/ プレフィックスを付与
+  const brokenLinks: string[] = [];
+  const transformed = llmsTxt.replace(MD_LINK_RE, (_match, path: string) => {
+    const newPath = `llms/${path}`;
+    const filePath = join(DOCS_DIR, newPath);
+    if (!existsSync(filePath)) {
+      brokenLinks.push(`${path} -> ${filePath}`);
+    }
+    return `](${newPath})`;
+  });
+
+  // 3. docs/llms.txt として保存
+  await Bun.write(LLMS_TXT_DEST, transformed);
+  console.log(`Generated: ${LLMS_TXT_DEST}`);
+
+  // 4. リンク存在チェック
+  if (brokenLinks.length > 0) {
+    console.error("Broken links detected in llms.txt:");
+    for (const link of brokenLinks) {
+      console.error(`  - ${link}`);
+    }
+    process.exit(1);
+  }
+
+  // 5. 全 .md ファイルを収集してソート
+  const mdFiles = await collectMdFiles(LLMS_DIR);
+  mdFiles.sort();
+
+  // 6. llms-full.txt を生成
+  const parts: string[] = [];
+  // ヘッダー部分（llms.txt の内容をそのまま含める）
+  parts.push(transformed);
+  parts.push("\n---\n");
+
+  for (const filePath of mdFiles) {
+    const relPath = relative(DOCS_DIR, filePath);
+    const content = await Bun.file(filePath).text();
+    parts.push(`\n## ${relPath}\n\n${content.trim()}\n`);
+  }
+
+  await Bun.write(LLMS_FULL_DEST, parts.join("\n"));
+  console.log(`Generated: ${LLMS_FULL_DEST}`);
+
+  // 7. サマリー
+  const fullSize = (await stat(LLMS_FULL_DEST)).size;
+  console.log(`Summary: ${mdFiles.length} markdown files, llms-full.txt = ${(fullSize / 1024).toFixed(1)} KB`);
+}
+
+main();

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://typedoc.org/schema.json",
+  "plugin": [],
   "entryPointStrategy": "packages",
   "entryPoints": ["packages/*"],
   "out": "docs",

--- a/typedoc.llms.json
+++ b/typedoc.llms.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://typedoc-plugin-markdown.org/schema.json",
+  "entryPointStrategy": "packages",
+  "entryPoints": ["packages/*"],
+  "out": "docs/llms",
+  "name": "wdpr",
+  "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-llms-txt"],
+  "packageOptions": {
+    "entryPoints": ["src/**/*.ts"],
+    "validation": {
+      "notExported": false
+    }
+  },
+  "hidePageHeader": true,
+  "hideBreadcrumbs": true,
+  "useCodeBlocks": true,
+  "llmsTxtHeader": {
+    "description": "Wikidot markup parser and HTML renderer for TypeScript"
+  }
+}


### PR DESCRIPTION
## Summary

   - TypeDoc HTML ドキュメントに加え、LLM 向けの `llms.txt` / `llms-full.txt` / Markdown ドキュメントを生成し GitHub Pages で配信する仕組みを追加
   - `typedoc-plugin-markdown` と `typedoc-plugin-llms-txt` を組み合わせて実現
   - 既存の HTML 出力は `typedoc.json` に `"plugin": []` を明示することで影響なし

   ### 生成される出力構造

   ```
   docs/
   ├── index.html          # TypeDoc HTML（人間向け、既存）
   ├── llms.txt            # LLM インデックス
   ├── llms-full.txt       # 全ドキュメント結合（645ファイル、626.6 KB）
   └── llms/               # Markdown（LLM 向け）
       ├── @wdprlib/ast/
       ├── @wdprlib/parser/
       ├── @wdprlib/render/
       └── @wdprlib/runtime/
   ```

   ### 変更内容

   - `typedoc-plugin-llms-txt`, `typedoc-plugin-markdown` を devDependencies に追加
   - `typedoc.json` に `"plugin": []` を追加（プラグイン自動読込防止）
   - `typedoc.llms.json` を新規作成（Markdown + llms.txt 生成用設定）
   - `scripts/build-llms.ts` を新規作成（llms.txt パス調整 + llms-full.txt 生成）
   - `package.json` に `docs:llms`, `docs:all` スクリプトを追加
   - `.github/workflows/docs.yml` を `docs:all` に変更 + paths トリガー追加