### PR TITLE
fix: パーサー・レンダラーの軽微なバグ4件を修正

### DIFF
--- a/packages/parser/src/parser/rules/block/module/include/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/include/resolve.ts
@@ -110,12 +110,34 @@ function parseIncludeDirective(inner: string): { location: PageRef; variables: V
 
   // Split by pipe to get target and variable assignments
   const parts = normalized.split("|");
-  const target = parts[0]!.trim();
+  const firstSegment = parts[0]!.trim();
 
-  const variables: VariableMap = {};
+  // Separate page name from space-separated parameters in the first segment.
+  // e.g. "component:coltop show=+ 開く" → target="component:coltop", rest="show=+ 開く"
+  const spaceIndex = firstSegment.indexOf(" ");
+  let target: string;
+  const varSegments: string[] = [];
+
+  if (spaceIndex !== -1) {
+    target = firstSegment.slice(0, spaceIndex);
+    const rest = firstSegment.slice(spaceIndex + 1).trim();
+    if (rest) {
+      varSegments.push(rest);
+    }
+  } else {
+    target = firstSegment;
+  }
+
+  // Collect pipe-separated variable segments
   for (let i = 1; i < parts.length; i++) {
     const segment = parts[i]!.trim();
-    if (!segment) continue;
+    if (segment) {
+      varSegments.push(segment);
+    }
+  }
+
+  const variables: VariableMap = {};
+  for (const segment of varSegments) {
     const eqIndex = segment.indexOf("=");
     if (eqIndex !== -1) {
       const key = segment.slice(0, eqIndex).trim();

--- a/packages/parser/src/parser/rules/inline/bibcite.ts
+++ b/packages/parser/src/parser/rules/inline/bibcite.ts
@@ -98,6 +98,7 @@ export const bibciteRule: InlineRule = {
 
     // Collect label (may span multiple tokens until ))
     let label = "";
+    let foundClose = false;
     while (pos < ctx.tokens.length) {
       const t = ctx.tokens[pos];
       if (!t) break;
@@ -108,6 +109,7 @@ export const bibciteRule: InlineRule = {
         if (nextT?.type === "TEXT" && nextT.value === ")") {
           // Found closing ))
           consumed += 2;
+          foundClose = true;
           break;
         }
       }
@@ -120,6 +122,10 @@ export const bibciteRule: InlineRule = {
       label += t.value;
       pos++;
       consumed++;
+    }
+
+    if (!foundClose) {
+      return { success: false };
     }
 
     label = label.trim();

--- a/packages/parser/src/parser/rules/inline/line-break.ts
+++ b/packages/parser/src/parser/rules/inline/line-break.ts
@@ -100,16 +100,10 @@ export const newlineLineBreakRule: InlineRule = {
     const nextMeaningfulToken = ctx.tokens[ctx.pos + lookAhead];
 
     // Check if HEADING_MARKER would actually form a valid heading
-    // Also check lineStart for list markers - they're only valid at true line start
+    // Block-start tokens are only valid when at actual line start
     let isValidBlock = isBlockStartToken(nextMeaningfulToken?.type as TokenType);
-    if (
-      isValidBlock &&
-      (nextMeaningfulToken?.type === "LIST_BULLET" || nextMeaningfulToken?.type === "LIST_NUMBER")
-    ) {
-      // List markers are only valid block starts when at actual line start
-      if (!nextMeaningfulToken.lineStart) {
-        isValidBlock = false;
-      }
+    if (isValidBlock && !nextMeaningfulToken?.lineStart) {
+      isValidBlock = false;
     }
     if (isValidBlock && nextMeaningfulToken?.type === "HEADING_MARKER") {
       const markerLen = nextMeaningfulToken.value.length;

--- a/packages/render/src/elements/module/join.ts
+++ b/packages/render/src/elements/module/join.ts
@@ -11,7 +11,7 @@
 
 import type { Module } from "@wdprlib/ast";
 import type { RenderContext } from "../../context";
-import { escapeHtml } from "../../escape";
+import { escapeAttr, escapeHtml } from "../../escape";
 
 /**
  * Render a `[[module Join]]` element with a clickable join button.
@@ -27,7 +27,7 @@ export function renderJoin(ctx: RenderContext, data: Extract<Module, { module: "
   const buttonText = data["button-text"] ?? "Join";
   const attrs = data.attributes ?? {};
   const className = attrs.class ?? "join-box";
-  ctx.push(`<div class="${escapeHtml(className)}">`);
+  ctx.push(`<div class="${escapeAttr(className)}">`);
   ctx.push(`<a href="javascript:;">${escapeHtml(buttonText)}</a>`);
   ctx.push("</div>");
 }

--- a/tests/unit/module/include/resolve.test.ts
+++ b/tests/unit/module/include/resolve.test.ts
@@ -171,6 +171,32 @@ describe("resolveIncludes", () => {
     expect(expanded).toContain("{$site}");
   });
 
+  test("handles space-separated parameters in first segment", () => {
+    const source = "[[include component:coltop show=+ 開く|hide=- 閉じる]]";
+    let receivedPageRef: { site: string | null; page: string } | null = null;
+    const fetcher = (pageRef: { site: string | null; page: string }) => {
+      receivedPageRef = pageRef;
+      return "Content with {$show} and {$hide}";
+    };
+
+    const expanded = resolveIncludes(source, fetcher);
+    expect(receivedPageRef!.page).toBe("component:coltop");
+    expect(expanded).toContain("Content with + 開く and - 閉じる");
+  });
+
+  test("handles space-separated parameters without pipe", () => {
+    const source = "[[include my-page key=value]]";
+    let receivedPageRef: { site: string | null; page: string } | null = null;
+    const fetcher = (pageRef: { site: string | null; page: string }) => {
+      receivedPageRef = pageRef;
+      return "Got {$key}";
+    };
+
+    const expanded = resolveIncludes(source, fetcher);
+    expect(receivedPageRef!.page).toBe("my-page");
+    expect(expanded).toContain("Got value");
+  });
+
   test("preserves surrounding text", () => {
     const source = "Before\n[[include my-page]]\nAfter";
     const fetcher = () => "Included";


### PR DESCRIPTION
## Summary

 - join.tsのclass属性で`escapeHtml`→`escapeAttr`に変更（XSS対策、CodeQL #7解決）
 - resolveIncludesでスペース区切りパラメータがページ名に含まれるバグを修正
 - bibciteで`))` なしの入力が成功扱いになる問題を修正
 - ブロック開始トークンの`lineStart`チェックをLIST以外にも統一

 ## 変更内容

 ### 1. join.ts: escapeAttr使用 (sec)
 `escapeHtml`は`"`をエスケープしないため、HTML属性値内で使用するとattribute breakoutの可能性があった。`escapeAttr`に変更。

 ### 2. resolveIncludes: スペース区切りパラメータ (bug)
 `[[include component:coltop show=+ 開く|hide=- 閉じる]]` でスペース区切りのパラメータがページ名に混入していた。block-levelパーサーと同様に最初のスペースで分離するロジックを追加。テスト2件追加。

 ### 3. bibcite: 閉じ括弧チェック (bug)
 `((bibcite label` のように`))` なしで入力が終わった場合に成功として扱われる可能性があった。`foundClose`フラグを追加。

 ### 4. linebreak: lineStartチェック統一 (bug)
 LIST_BULLET/LIST_NUMBERのみ`lineStart`を確認していたが、BLOCKQUOTE_MARKER、HR_MARKER、TABLE_MARKERにも同じチェックを適用。インデントされたブロックマーカーによる誤った`<br>`抑制を防止。