### PR TITLE
fix(parser): パーサーのminor bug 4件を修正

### DIFF
--- a/packages/parser/src/parser/rules/block/bibliography.ts
+++ b/packages/parser/src/parser/rules/block/bibliography.ts
@@ -160,7 +160,11 @@ function parseBibliographyEntry(
         consumed++;
         break;
       }
-      // Single newline - continue (becomes line break)
+      // Single newline - add line break and continue
+      contentNodes.push({ element: "line-break" });
+      pos++;
+      consumed++;
+      continue;
     }
 
     // Parse inline content

--- a/packages/parser/src/parser/rules/inline/anchor.ts
+++ b/packages/parser/src/parser/rules/inline/anchor.ts
@@ -203,9 +203,14 @@ export const anchorRule: InlineRule = {
           }
           foundClose = true;
 
-          // In paragraph strip mode, consume trailing newlines after close tag
-          // This prevents line-breaks between consecutive [[a_]] blocks
-          while (paragraphStrip && ctx.tokens[pos]?.type === "NEWLINE") {
+          // In paragraph strip mode, consume one trailing newline after close tag
+          // This prevents a line-break between consecutive [[a_]] blocks
+          // but preserves paragraph breaks (double newlines)
+          if (
+            paragraphStrip &&
+            ctx.tokens[pos]?.type === "NEWLINE" &&
+            ctx.tokens[pos + 1]?.type !== "NEWLINE"
+          ) {
             pos++;
             consumed++;
           }

--- a/packages/parser/src/parser/rules/inline/footnote.ts
+++ b/packages/parser/src/parser/rules/inline/footnote.ts
@@ -122,13 +122,18 @@ export const footnoteRule: InlineRule = {
       if (token.type === "NEWLINE") {
         pos++;
         consumed++;
-        // Skip whitespace between newlines (blank line with spaces)
-        while (ctx.tokens[pos]?.type === "WHITESPACE") {
-          pos++;
-          consumed++;
+        // Peek ahead: skip whitespace to check for blank line (e.g. "\n  \n")
+        let peekPos = pos;
+        let peekConsumed = 0;
+        while (ctx.tokens[peekPos]?.type === "WHITESPACE") {
+          peekPos++;
+          peekConsumed++;
         }
         // Look ahead for another NEWLINE (blank line = paragraph break)
-        if (ctx.tokens[pos]?.type === "NEWLINE") {
+        if (ctx.tokens[peekPos]?.type === "NEWLINE") {
+          // Commit the whitespace skip
+          pos = peekPos;
+          consumed += peekConsumed;
           // Skip all consecutive newlines
           while (ctx.tokens[pos]?.type === "NEWLINE") {
             pos++;

--- a/packages/parser/src/parser/rules/inline/footnote.ts
+++ b/packages/parser/src/parser/rules/inline/footnote.ts
@@ -122,6 +122,11 @@ export const footnoteRule: InlineRule = {
       if (token.type === "NEWLINE") {
         pos++;
         consumed++;
+        // Skip whitespace between newlines (blank line with spaces)
+        while (ctx.tokens[pos]?.type === "WHITESPACE") {
+          pos++;
+          consumed++;
+        }
         // Look ahead for another NEWLINE (blank line = paragraph break)
         if (ctx.tokens[pos]?.type === "NEWLINE") {
           // Skip all consecutive newlines

--- a/packages/parser/src/parser/rules/inline/link-triple.ts
+++ b/packages/parser/src/parser/rules/inline/link-triple.ts
@@ -124,8 +124,13 @@ export const linkTripleRule: InlineRule = {
         break;
       }
 
-      // Skip newlines in link content (Wikidot allows this)
+      // Convert newlines to spaces in link content (Wikidot allows single newlines)
       if (token.type === "NEWLINE") {
+        if (foundPipe) {
+          labelText += " ";
+        } else {
+          target += " ";
+        }
         consumed++;
         pos++;
         continue;

--- a/tests/fixtures/anchor/basic/expected.json
+++ b/tests/fixtures/anchor/basic/expected.json
@@ -236,7 +236,16 @@
                 }
               ]
             }
-          },
+          }
+        ]
+      }
+    },
+    {
+      "element": "container",
+      "data": {
+        "type": "paragraph",
+        "attributes": {},
+        "elements": [
           {
             "element": "container",
             "data": {

--- a/tests/fixtures/anchor/basic/output.html
+++ b/tests/fixtures/anchor/basic/output.html
@@ -1,9 +1,1 @@
-<p>EMPTY <a href=""></a><br />
-BASIC <a href="some-page">click</a><br />
-ATTRS <a id="u-awesome" style="color: purple" href="https://example.com">my link</a><br />
-DEPTH <a href="https://example.com">my <strong>awesome</strong> link</a></p>
-<p><strong>SCORE</strong></p>
-<p>EMPTY <a href=""></a>BASIC <a href="some-page">click</a>ATTRS <a class="link" href="https://example.com">my link</a><strong>NAMED</strong></p>
-<p><a name="apple"></a> A<br />
-<a name="apple-banana"></a> B<br />
-<a name="pineapple"></a><a name="mango"></a> <a name="strawberry"></a>C</p>
+<p>EMPTY <a href=""></a><br />BASIC <a href="some-page">click</a><br />ATTRS <a href="https://example.com" style="color: purple" id="u-awesome">my link</a><br />DEPTH <a href="https://example.com">my <strong>awesome</strong> link</a></p><p><strong>SCORE</strong></p><p>EMPTY <a href=""></a>BASIC <a href="some-page">click</a>ATTRS <a href="https://example.com" class="link">my link</a></p><p><strong>NAMED</strong></p><p><a name="apple"></a> A<br /><a name="apple-banana"></a> B<br /><a name="pineapple"></a><a name="mango"></a> <a name="strawberry"></a>C</p>


### PR DESCRIPTION
## Summary

パーサーのminor bugを4件修正。

- `[[a_]]`閉じタグ後のNEWLINE消費が段落区切り（二重改行）まで食い潰す問題を修正
- bibliography本文中の単一改行がline-break要素として生成されない問題を修正
- footnote内の改行間にスペースがある空白行（`\n  \n`）が段落区切りとして認識されない問題を修正
- `[[[target | label]]]`内のNEWLINEトークンが消失する問題を修正