### PR TITLE
docs(parser): #18・#20の修正に合わせてJSDocを更新

### DIFF
--- a/packages/parser/src/parser/rules/block/bibliography.ts
+++ b/packages/parser/src/parser/rules/block/bibliography.ts
@@ -53,7 +53,8 @@ interface BibliographyEntry {
  * The entry starts with a COLON token at line start, followed by mandatory
  * whitespace, then the label text, a second COLON, and the citation content.
  * Content parsing continues until a double newline, a new entry (`: ...`),
- * or the closing `[[/bibliography]]` tag is reached.
+ * or the closing `[[/bibliography]]` tag is reached. Single newlines within
+ * the citation text produce `line-break` elements.
  *
  * @param ctx      - Current parse context.
  * @param startPos - Token index where the entry begins (expected COLON).

--- a/packages/parser/src/parser/rules/block/module/include/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/include/resolve.ts
@@ -98,8 +98,10 @@ const INCLUDE_PATTERN = /\[\[include\s([^\]]*(?:\](?!\])[^\]]*)*)\]\]/gi;
  * Parse the inner content of an `[[include ...]]` directive into a page reference
  * and variable assignments.
  *
- * The inner content has the format: `page-name | key1=value1 | key2=value2`
- * where the page name may include a cross-site prefix (`:site-name:page-name`).
+ * The inner content has the format: `page-name key1=value1 | key2=value2`
+ * where variable assignments can appear space-separated after the page name
+ * in the first segment (before any pipe), as well as in pipe-separated segments.
+ * The page name may include a cross-site prefix (`:site-name:page-name`).
  *
  * @param inner - The text between `[[include` and `]]`
  * @returns Object containing the parsed page location and variable map

--- a/packages/parser/src/parser/rules/inline/anchor.ts
+++ b/packages/parser/src/parser/rules/inline/anchor.ts
@@ -10,7 +10,8 @@
  * - `[[a_ href="url"]]text[[/a]]` -- paragraph strip mode (trailing underscore)
  *
  * Paragraph strip mode (`[[a_]]`) suppresses newlines within the anchor
- * body and strips trailing newlines after the closing tag. This prevents
+ * body and strips at most one trailing newline after the closing tag
+ * (preserving double newlines as paragraph breaks). This prevents
  * unwanted `<br>` elements when consecutive anchor blocks are placed on
  * separate lines.
  *
@@ -126,8 +127,11 @@ function parseAnchorBlockName(
  * Edge cases:
  * - If no matching closing tag is found, the rule fails (returns `{ success: false }`),
  *   allowing the tokens to fall through to other rules or the text fallback.
- * - In paragraph strip mode, newlines within the body and after the closing tag
- *   are consumed silently rather than converted to line-break elements.
+ * - In paragraph strip mode, newlines within the body are consumed silently
+ *   rather than converted to line-break elements. After the closing tag,
+ *   at most one trailing newline is consumed to prevent a line-break between
+ *   consecutive `[[a_]]` blocks, but double newlines are preserved as
+ *   paragraph breaks.
  * - The `href` attribute is sanitized to block `javascript:`, `data:`, and
  *   `vbscript:` schemes.
  */

--- a/packages/parser/src/parser/rules/inline/link-triple.ts
+++ b/packages/parser/src/parser/rules/inline/link-triple.ts
@@ -16,9 +16,9 @@
  * - `[[[*|label]]]` -- links to root `/` with the given label
  * - `[[[page|]]]` -- empty label after pipe defaults to the page name
  *
- * Multi-line support: a single newline is allowed within the link
- * (typically after the pipe), but a double newline (paragraph break) or
- * a newline directly before `]]]` invalidates the link.
+ * Multi-line support: a single newline within the link is converted to
+ * a space (in both target and label portions), but a double newline
+ * (paragraph break) or a newline directly before `]]]` invalidates the link.
  *
  * When the opening `[[[` has no valid closing `]]]`, it falls through
  * as literal text rather than failing.
@@ -111,7 +111,7 @@ export const linkTripleRule: InlineRule = {
       };
     }
 
-    // Collect tokens until LINK_CLOSE (allowing single newline)
+    // Collect tokens until LINK_CLOSE (newlines converted to spaces)
     let target = "";
     let labelText = "";
     let foundPipe = false;


### PR DESCRIPTION
## Summary

PR #18・#20 で変更したパーサーの動作に合わせて、4ファイルのJSDocを更新。

- `anchor.ts`: 段落ストリップモードの改行消費の記述を「最大1つ、二重改行は保持」に修正
- `bibliography.ts`: 単一改行がline-break要素を生成する旨を追記
- `include/resolve.ts`: スペース区切りパラメータの対応を追記
- `link-triple.ts`: 改行がスペースに変換される動作を反映