### PR TITLE
fix(parser,render): [[iftags]]の条件評価バグとCSS漏出を修正

### DIFF
--- a/packages/ast/src/constants.ts
+++ b/packages/ast/src/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Sentinel prefix for style slot placeholders in {@link SyntaxTree.styles}.
+ *
+ * When the resolver encounters an unresolved `[[iftags]]` block containing
+ * `[[module CSS]]`, it inserts a sentinel string (`STYLE_SLOT_PREFIX + slotId`)
+ * into the styles array to preserve source order. At render time the sentinel
+ * is replaced with the actual CSS collected from the iftags block (if the
+ * condition matches).
+ *
+ * A null-byte prefix ensures no collision with valid CSS content.
+ */
+export const STYLE_SLOT_PREFIX = "\0__IFTAGS_SLOT__";

--- a/packages/ast/src/index.ts
+++ b/packages/ast/src/index.ts
@@ -104,6 +104,9 @@ export {
   isParagraphSafe,
 } from "./element";
 
+// Constants
+export { STYLE_SLOT_PREFIX } from "./constants";
+
 // Wikitext settings
 export type { WikitextMode, WikitextSettings } from "./settings";
 export { createSettings, DEFAULT_SETTINGS } from "./settings";

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -135,6 +135,7 @@ export type {
 export {
   extractDataRequirements,
   resolveModules,
+  STYLE_SLOT_PREFIX,
   compileTemplate,
   // Include resolution
   resolveIncludes,

--- a/packages/parser/src/parser/rules/block/module/iftags/condition.ts
+++ b/packages/parser/src/parser/rules/block/module/iftags/condition.ts
@@ -54,6 +54,11 @@ export function parseTagCondition(condition: string): TagCondition {
  * @returns true if condition is satisfied
  */
 export function evaluateTagCondition(condition: TagCondition, pageTags: string[]): boolean {
+  // Empty condition = never match (supercommentout)
+  if (condition.required.length === 0 && condition.forbidden.length === 0) {
+    return false;
+  }
+
   const tagSet = new Set(pageTags);
 
   // All required tags must be present

--- a/packages/parser/src/parser/rules/block/module/iftags/condition.ts
+++ b/packages/parser/src/parser/rules/block/module/iftags/condition.ts
@@ -20,7 +20,7 @@ import type { TagCondition } from "./types";
  * Parse iftags condition string into structured format
  *
  * @param condition - Raw condition string like "+fruit -admin component"
- * @returns Parsed condition with required and forbidden tags
+ * @returns Parsed condition with required, forbidden, and optional tags
  */
 export function parseTagCondition(condition: string): TagCondition {
   const required: string[] = [];

--- a/packages/parser/src/parser/rules/block/module/iftags/condition.ts
+++ b/packages/parser/src/parser/rules/block/module/iftags/condition.ts
@@ -6,10 +6,10 @@
  * token is a tag name with an optional prefix:
  * - `+tag` - Tag must be present (AND condition)
  * - `-tag` - Tag must be absent (NOT condition)
- * - `tag` - Tag must be present (same as `+tag`)
+ * - `tag` - At least one bare tag must be present (OR condition)
  *
- * All required tags must be present AND all forbidden tags must be absent
- * for the condition to evaluate to true.
+ * All three categories must independently be satisfied:
+ * required (AND) + forbidden (AND) + optional (OR).
  *
  * @module
  */
@@ -25,6 +25,7 @@ import type { TagCondition } from "./types";
 export function parseTagCondition(condition: string): TagCondition {
   const required: string[] = [];
   const forbidden: string[] = [];
+  const optional: string[] = [];
 
   const parts = condition.trim().split(/\s+/);
 
@@ -38,12 +39,11 @@ export function parseTagCondition(condition: string): TagCondition {
       const tag = part.slice(1);
       if (tag) forbidden.push(tag);
     } else {
-      // No prefix means required
-      required.push(part);
+      optional.push(part);
     }
   }
 
-  return { required, forbidden };
+  return { required, forbidden, optional };
 }
 
 /**
@@ -55,7 +55,11 @@ export function parseTagCondition(condition: string): TagCondition {
  */
 export function evaluateTagCondition(condition: TagCondition, pageTags: string[]): boolean {
   // Empty condition = never match (supercommentout)
-  if (condition.required.length === 0 && condition.forbidden.length === 0) {
+  if (
+    condition.required.length === 0 &&
+    condition.forbidden.length === 0 &&
+    condition.optional.length === 0
+  ) {
     return false;
   }
 
@@ -71,6 +75,13 @@ export function evaluateTagCondition(condition: TagCondition, pageTags: string[]
   // All forbidden tags must be absent
   for (const tag of condition.forbidden) {
     if (tagSet.has(tag)) {
+      return false;
+    }
+  }
+
+  // At least one optional tag must be present (if any specified)
+  if (condition.optional.length > 0) {
+    if (!condition.optional.some((tag) => tagSet.has(tag))) {
       return false;
     }
   }

--- a/packages/parser/src/parser/rules/block/module/iftags/types.ts
+++ b/packages/parser/src/parser/rules/block/module/iftags/types.ts
@@ -4,7 +4,7 @@
  *
  * `[[iftags]]` is a Wikidot block that conditionally renders its content
  * based on the current page's tags. The condition syntax supports required
- * tags (`+tag` or bare `tag`) and forbidden tags (`-tag`).
+ * tags (`+tag`), forbidden tags (`-tag`), and optional tags (bare `tag`).
  *
  * @module
  */

--- a/packages/parser/src/parser/rules/block/module/iftags/types.ts
+++ b/packages/parser/src/parser/rules/block/module/iftags/types.ts
@@ -12,24 +12,28 @@
 /**
  * Parsed representation of an `[[iftags +tag -tag ...]]` condition.
  *
- * The condition string is parsed into two arrays:
- * - `required` tags must ALL be present on the page for the condition to match
- * - `forbidden` tags must ALL be absent from the page for the condition to match
+ * The condition string is parsed into three arrays:
+ * - `required` tags must ALL be present on the page (AND logic, `+tag` syntax)
+ * - `forbidden` tags must ALL be absent from the page (AND logic, `-tag` syntax)
+ * - `optional` tags require at least ONE to be present (OR logic, bare `tag` syntax)
  *
- * Both conditions must be satisfied simultaneously (AND logic).
+ * All three categories must independently be satisfied.
  *
  * @example
- * `[[iftags +fruit -admin component]]` parses to:
+ * `[[iftags +fruit -admin component template]]` parses to:
  * ```
- * { required: ["fruit", "component"], forbidden: ["admin"] }
+ * { required: ["fruit"], forbidden: ["admin"], optional: ["component", "template"] }
  * ```
  */
 export interface TagCondition {
-  /** Tags that must all be present on the page (`+tag` or bare `tag` syntax) */
+  /** Tags that must all be present on the page (`+tag` syntax) */
   required: string[];
 
   /** Tags that must all be absent from the page (`-tag` syntax) */
   forbidden: string[];
+
+  /** Tags where at least one must be present (bare `tag` syntax, OR logic) */
+  optional: string[];
 }
 
 /**

--- a/packages/parser/src/parser/rules/block/module/index.ts
+++ b/packages/parser/src/parser/rules/block/module/index.ts
@@ -112,4 +112,4 @@ export {
 
 // Module resolver
 export type { ResolveOptions } from "./resolve";
-export { resolveModules } from "./resolve";
+export { resolveModules, STYLE_SLOT_PREFIX } from "./resolve";

--- a/packages/parser/src/parser/rules/block/module/index.ts
+++ b/packages/parser/src/parser/rules/block/module/index.ts
@@ -112,4 +112,5 @@ export {
 
 // Module resolver
 export type { ResolveOptions } from "./resolve";
-export { resolveModules, STYLE_SLOT_PREFIX } from "./resolve";
+export { resolveModules } from "./resolve";
+export { STYLE_SLOT_PREFIX } from "@wdprlib/ast";

--- a/packages/parser/src/parser/rules/block/module/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/resolve.ts
@@ -358,7 +358,10 @@ function countModulesInElements(elements: Element[]): { listPages: number; listU
  * Collect and remove style elements from the AST.
  *
  * Walks the element tree recursively, extracting style elements
- * from any depth and returning them separately.
+ * from any depth and returning them separately. Unresolved `if-tags`
+ * elements are skipped — their internal styles remain in the AST and
+ * are rendered inline at render time when the condition is evaluated.
+ *
  * The order of collected styles reflects their appearance order in the AST.
  */
 function collectStyles(elements: Element[]): { elements: Element[]; styles: string[] } {

--- a/packages/parser/src/parser/rules/block/module/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/resolve.ts
@@ -376,6 +376,14 @@ function collectStylesFromElements(elements: Element[], styles: string[]): Eleme
       continue;
     }
 
+    // Unresolved iftags: keep as-is without extracting internal styles.
+    // Styles inside will be rendered inline when the iftags condition
+    // is evaluated at render time.
+    if (element.element === "if-tags") {
+      result.push(element);
+      continue;
+    }
+
     // Recurse into children using mapElementChildren
     const mapped = mapElementChildren(element, (children) =>
       collectStylesFromElements(children, styles),

--- a/packages/parser/src/parser/rules/block/module/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/resolve.ts
@@ -17,6 +17,7 @@
  */
 
 import type { Element, SyntaxTree } from "@wdprlib/ast";
+import { STYLE_SLOT_PREFIX } from "@wdprlib/ast";
 import type { DataProvider } from "./types-common";
 import { walkElements, mapElementChildren, mapElementChildrenWithState } from "./walk";
 import type {
@@ -364,11 +365,6 @@ function countModulesInElements(elements: Element[]): { listPages: number; listU
  *
  * The order of collected styles reflects their appearance order in the AST.
  */
-/**
- * Sentinel prefix for style slot placeholders in the styles array.
- * A null byte prefix ensures no collision with valid CSS content.
- */
-export const STYLE_SLOT_PREFIX = "\0__IFTAGS_SLOT__";
 
 function collectStyles(elements: Element[]): { elements: Element[]; styles: string[] } {
   const styles: string[] = [];

--- a/packages/parser/src/parser/rules/block/module/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/resolve.ts
@@ -364,13 +364,24 @@ function countModulesInElements(elements: Element[]): { listPages: number; listU
  *
  * The order of collected styles reflects their appearance order in the AST.
  */
+/**
+ * Sentinel prefix for style slot placeholders in the styles array.
+ * A null byte prefix ensures no collision with valid CSS content.
+ */
+export const STYLE_SLOT_PREFIX = "\0__IFTAGS_SLOT__";
+
 function collectStyles(elements: Element[]): { elements: Element[]; styles: string[] } {
   const styles: string[] = [];
-  const filtered = collectStylesFromElements(elements, styles);
+  const ctx = { nextSlotId: 0 };
+  const filtered = collectStylesFromElements(elements, styles, ctx);
   return { elements: filtered, styles };
 }
 
-function collectStylesFromElements(elements: Element[], styles: string[]): Element[] {
+function collectStylesFromElements(
+  elements: Element[],
+  styles: string[],
+  ctx: { nextSlotId: number },
+): Element[] {
   const result: Element[] = [];
 
   for (const element of elements) {
@@ -379,17 +390,23 @@ function collectStylesFromElements(elements: Element[], styles: string[]): Eleme
       continue;
     }
 
-    // Unresolved iftags: keep as-is without extracting internal styles.
-    // Styles inside will be rendered inline when the iftags condition
-    // is evaluated at render time.
+    // Unresolved iftags: insert a style-slot placeholder to preserve
+    // source-order of styles relative to other collected styles.
+    // The slot ID is attached to the element data so the renderer can
+    // collect styles into the correct slot at render time.
     if (element.element === "if-tags") {
-      result.push(element);
+      const slotId = ctx.nextSlotId++;
+      styles.push(`${STYLE_SLOT_PREFIX}${slotId}`);
+      result.push({
+        element: "if-tags",
+        data: { ...(element.data as IfTagsData), _styleSlot: slotId },
+      } as unknown as Element);
       continue;
     }
 
     // Recurse into children using mapElementChildren
     const mapped = mapElementChildren(element, (children) =>
-      collectStylesFromElements(children, styles),
+      collectStylesFromElements(children, styles, ctx),
     );
     result.push(mapped);
   }

--- a/packages/render/src/context.ts
+++ b/packages/render/src/context.ts
@@ -44,6 +44,13 @@ import { escapeHtml, escapeAttr, sanitizeAttributes } from "./escape";
 export class RenderContext {
   /** Accumulated HTML fragments; joined by {@link getOutput}. */
   private chunks: string[] = [];
+  /**
+   * When true, style elements in the AST should be rendered inline as
+   * `<style>` tags rather than being silently skipped. This is set while
+   * rendering children of unresolved `[[iftags]]` blocks whose styles
+   * were intentionally not collected during resolve.
+   */
+  renderInlineStyles = false;
   /** Auto-incrementing counter for table-of-contents heading IDs. */
   private _tocIndex = 0;
   /** Auto-incrementing counter for footnote reference/body IDs. */

--- a/packages/render/src/context.ts
+++ b/packages/render/src/context.ts
@@ -45,12 +45,19 @@ export class RenderContext {
   /** Accumulated HTML fragments; joined by {@link getOutput}. */
   private chunks: string[] = [];
   /**
-   * When true, style elements in the AST should be rendered inline as
-   * `<style>` tags rather than being silently skipped. This is set while
-   * rendering children of unresolved `[[iftags]]` blocks whose styles
-   * were intentionally not collected during resolve.
+   * When true, style elements in the AST are rendered rather than
+   * silently skipped. Set while rendering children of unresolved
+   * `[[iftags]]` blocks whose styles were not collected during resolve.
    */
   renderInlineStyles = false;
+  /**
+   * Active style slot ID. When set, style content is collected into
+   * the slot (via {@link pushToStyleSlot}) instead of being rendered
+   * inline, preserving source-order relative to other collected styles.
+   */
+  private _styleSlotId: number | null = null;
+  /** Collected CSS strings per style slot, keyed by slot ID. */
+  private _styleSlotContents = new Map<number, string[]>();
   /** Auto-incrementing counter for table-of-contents heading IDs. */
   private _tocIndex = 0;
   /** Auto-incrementing counter for footnote reference/body IDs. */
@@ -167,6 +174,36 @@ export class RenderContext {
    */
   getOutput(): string {
     return this.chunks.join("");
+  }
+
+  /** Enter a style slot: subsequent {@link pushToStyleSlot} calls collect into this slot. */
+  enterStyleSlot(slotId: number): void {
+    this._styleSlotId = slotId;
+    if (!this._styleSlotContents.has(slotId)) {
+      this._styleSlotContents.set(slotId, []);
+    }
+  }
+
+  /** Exit the current style slot. */
+  exitStyleSlot(): void {
+    this._styleSlotId = null;
+  }
+
+  /** Whether a style slot is currently active. */
+  hasActiveStyleSlot(): boolean {
+    return this._styleSlotId !== null;
+  }
+
+  /** Push a CSS string into the active style slot. */
+  pushToStyleSlot(css: string): void {
+    if (this._styleSlotId !== null) {
+      this._styleSlotContents.get(this._styleSlotId)!.push(css);
+    }
+  }
+
+  /** Retrieve collected CSS strings for a given style slot. */
+  getStyleSlotContents(slotId: number): string[] {
+    return this._styleSlotContents.get(slotId) ?? [];
   }
 
   /**

--- a/packages/render/src/elements/iftags.ts
+++ b/packages/render/src/elements/iftags.ts
@@ -18,8 +18,7 @@
 
 import type { IfTagsData } from "@wdprlib/ast";
 import type { RenderContext } from "../context";
-import { escapeStyleContent } from "../escape";
-import { renderElement } from "../render";
+import { renderElements } from "../render";
 
 /**
  * Evaluate an iftags condition string against a list of page tags.
@@ -91,15 +90,12 @@ export function renderIfTags(ctx: RenderContext, data: IfTagsData): void {
   const pageTags = ctx.page?.tags ?? [];
 
   if (evaluateIfTagsCondition(data.condition, pageTags)) {
-    // Process children in source order. Style elements that were not
-    // collected during resolve (inside unresolved iftags) are rendered
-    // inline to maintain correct CSS ordering.
-    for (const el of data.elements) {
-      if (el.element === "style" && ctx.settings.allowStyleElements) {
-        ctx.push(`<style>${escapeStyleContent(el.data)}</style>`);
-      } else {
-        renderElement(ctx, el);
-      }
-    }
+    // Enable inline style rendering for children. Style elements inside
+    // unresolved iftags were not collected during resolve, so they must
+    // be rendered inline here (at any nesting depth).
+    const prev = ctx.renderInlineStyles;
+    ctx.renderInlineStyles = true;
+    renderElements(ctx, data.elements);
+    ctx.renderInlineStyles = prev;
   }
 }

--- a/packages/render/src/elements/iftags.ts
+++ b/packages/render/src/elements/iftags.ts
@@ -90,12 +90,22 @@ export function renderIfTags(ctx: RenderContext, data: IfTagsData): void {
   const pageTags = ctx.page?.tags ?? [];
 
   if (evaluateIfTagsCondition(data.condition, pageTags)) {
-    // Enable inline style rendering for children. Style elements inside
-    // unresolved iftags were not collected during resolve, so they must
-    // be rendered inline here (at any nesting depth).
     const prev = ctx.renderInlineStyles;
     ctx.renderInlineStyles = true;
+
+    // If a style slot was assigned during resolve, collect styles into
+    // it so they appear at the correct source-order position in the
+    // final output. Otherwise fall back to inline rendering.
+    const slotId = (data as IfTagsData & { _styleSlot?: number })._styleSlot;
+    if (slotId !== undefined) {
+      ctx.enterStyleSlot(slotId);
+    }
+
     renderElements(ctx, data.elements);
+
+    if (slotId !== undefined) {
+      ctx.exitStyleSlot();
+    }
     ctx.renderInlineStyles = prev;
   }
 }

--- a/packages/render/src/elements/iftags.ts
+++ b/packages/render/src/elements/iftags.ts
@@ -18,7 +18,8 @@
 
 import type { IfTagsData } from "@wdprlib/ast";
 import type { RenderContext } from "../context";
-import { renderElements } from "../render";
+import { escapeStyleContent } from "../escape";
+import { renderElement } from "../render";
 
 /**
  * Evaluate an iftags condition string against a list of page tags.
@@ -90,6 +91,15 @@ export function renderIfTags(ctx: RenderContext, data: IfTagsData): void {
   const pageTags = ctx.page?.tags ?? [];
 
   if (evaluateIfTagsCondition(data.condition, pageTags)) {
-    renderElements(ctx, data.elements);
+    // Process children in source order. Style elements that were not
+    // collected during resolve (inside unresolved iftags) are rendered
+    // inline to maintain correct CSS ordering.
+    for (const el of data.elements) {
+      if (el.element === "style" && ctx.settings.allowStyleElements) {
+        ctx.push(`<style>${escapeStyleContent(el.data)}</style>`);
+      } else {
+        renderElement(ctx, el);
+      }
+    }
   }
 }

--- a/packages/render/src/elements/iftags.ts
+++ b/packages/render/src/elements/iftags.ts
@@ -49,12 +49,19 @@ function evaluateIfTagsCondition(condition: string, pageTags: string[]): boolean
 
   for (const token of tokens) {
     if (token.startsWith("+")) {
-      required.push(token.slice(1).toLowerCase());
+      const tag = token.slice(1).toLowerCase();
+      if (tag) required.push(tag);
     } else if (token.startsWith("-")) {
-      excluded.push(token.slice(1).toLowerCase());
+      const tag = token.slice(1).toLowerCase();
+      if (tag) excluded.push(tag);
     } else {
       optional.push(token.toLowerCase());
     }
+  }
+
+  // If all tokens had empty tag names (e.g. "+" or "-"), treat as empty condition
+  if (required.length === 0 && excluded.length === 0 && optional.length === 0) {
+    return false;
   }
 
   // All required tags must be present

--- a/packages/render/src/render.ts
+++ b/packages/render/src/render.ts
@@ -178,7 +178,9 @@ export function renderElement(ctx: RenderContext, element: Element): void {
       renderIfTags(ctx, element.data);
       break;
     case "style":
-      // Styles are collected and rendered at the end
+      // Styles are collected into tree.styles during resolve and rendered
+      // at the end of renderToHtml. Style elements remaining in the AST
+      // (e.g. inside unresolved iftags) are handled by renderIfTags.
       break;
     case "line-break":
       ctx.push("<br />");

--- a/packages/render/src/render.ts
+++ b/packages/render/src/render.ts
@@ -180,7 +180,11 @@ export function renderElement(ctx: RenderContext, element: Element): void {
     case "style":
       // Styles are collected into tree.styles during resolve and rendered
       // at the end of renderToHtml. Style elements remaining in the AST
-      // (e.g. inside unresolved iftags) are handled by renderIfTags.
+      // (inside unresolved iftags) are rendered inline when the
+      // renderInlineStyles flag is set by renderIfTags.
+      if (ctx.renderInlineStyles && ctx.settings.allowStyleElements) {
+        ctx.push(`<style>${escapeStyleContent(element.data)}</style>`);
+      }
       break;
     case "line-break":
       ctx.push("<br />");

--- a/packages/render/src/render.ts
+++ b/packages/render/src/render.ts
@@ -1,4 +1,5 @@
 import type { Element, SyntaxTree } from "@wdprlib/ast";
+import { STYLE_SLOT_PREFIX } from "@wdprlib/parser";
 import { RenderContext } from "./context";
 import { escapeStyleContent } from "./escape";
 import type { RenderOptions } from "./types";
@@ -47,10 +48,19 @@ export function renderToHtml(tree: SyntaxTree, options: RenderOptions = {}): str
   const ctx = new RenderContext(tree, options);
   renderElements(ctx, tree.elements);
 
-  // Append styles (with tag breakout prevention)
+  // Append styles (with tag breakout prevention).
+  // Sentinel entries (STYLE_SLOT_PREFIX) mark positions where unresolved
+  // iftags styles should be spliced in, preserving source order.
   if (ctx.settings.allowStyleElements && tree.styles?.length) {
     for (const style of tree.styles) {
-      ctx.push(`<style>${escapeStyleContent(style)}</style>`);
+      if (style.startsWith(STYLE_SLOT_PREFIX)) {
+        const slotId = parseInt(style.slice(STYLE_SLOT_PREFIX.length), 10);
+        for (const css of ctx.getStyleSlotContents(slotId)) {
+          ctx.push(`<style>${escapeStyleContent(css)}</style>`);
+        }
+      } else {
+        ctx.push(`<style>${escapeStyleContent(style)}</style>`);
+      }
     }
   }
 
@@ -180,10 +190,14 @@ export function renderElement(ctx: RenderContext, element: Element): void {
     case "style":
       // Styles are collected into tree.styles during resolve and rendered
       // at the end of renderToHtml. Style elements remaining in the AST
-      // (inside unresolved iftags) are rendered inline when the
-      // renderInlineStyles flag is set by renderIfTags.
+      // (inside unresolved iftags) are either collected into a style slot
+      // (preserving source order) or rendered inline as a fallback.
       if (ctx.renderInlineStyles && ctx.settings.allowStyleElements) {
-        ctx.push(`<style>${escapeStyleContent(element.data)}</style>`);
+        if (ctx.hasActiveStyleSlot()) {
+          ctx.pushToStyleSlot(element.data);
+        } else {
+          ctx.push(`<style>${escapeStyleContent(element.data)}</style>`);
+        }
       }
       break;
     case "line-break":

--- a/packages/render/src/render.ts
+++ b/packages/render/src/render.ts
@@ -1,5 +1,5 @@
 import type { Element, SyntaxTree } from "@wdprlib/ast";
-import { STYLE_SLOT_PREFIX } from "@wdprlib/parser";
+import { STYLE_SLOT_PREFIX } from "@wdprlib/ast";
 import { RenderContext } from "./context";
 import { escapeStyleContent } from "./escape";
 import type { RenderOptions } from "./types";

--- a/tests/unit/module/iftags/condition.test.ts
+++ b/tests/unit/module/iftags/condition.test.ts
@@ -81,13 +81,13 @@ describe("evaluateTagCondition", () => {
     expect(evaluateTagCondition(condition, ["fruit", "public"])).toBe(true);
   });
 
-  test("matches empty condition with any tags", () => {
+  test("empty condition never matches (supercommentout)", () => {
     const condition = { required: [], forbidden: [] };
-    expect(evaluateTagCondition(condition, ["any", "tags"])).toBe(true);
+    expect(evaluateTagCondition(condition, ["any", "tags"])).toBe(false);
   });
 
-  test("matches empty condition with empty tags", () => {
+  test("empty condition never matches even with empty tags", () => {
     const condition = { required: [], forbidden: [] };
-    expect(evaluateTagCondition(condition, [])).toBe(true);
+    expect(evaluateTagCondition(condition, [])).toBe(false);
   });
 });

--- a/tests/unit/module/iftags/condition.test.ts
+++ b/tests/unit/module/iftags/condition.test.ts
@@ -5,89 +5,132 @@ import {
 } from "../../../../packages/parser/src/parser/rules/block/module/iftags";
 
 describe("parseTagCondition", () => {
-  test("parses required tags without prefix", () => {
+  test("parses bare tags as optional", () => {
     const result = parseTagCondition("fruit vegetable");
-    expect(result.required).toEqual(["fruit", "vegetable"]);
+    expect(result.required).toEqual([]);
     expect(result.forbidden).toEqual([]);
+    expect(result.optional).toEqual(["fruit", "vegetable"]);
   });
 
   test("parses required tags with + prefix", () => {
     const result = parseTagCondition("+fruit +vegetable");
     expect(result.required).toEqual(["fruit", "vegetable"]);
     expect(result.forbidden).toEqual([]);
+    expect(result.optional).toEqual([]);
   });
 
   test("parses forbidden tags with - prefix", () => {
     const result = parseTagCondition("-admin -hidden");
     expect(result.required).toEqual([]);
     expect(result.forbidden).toEqual(["admin", "hidden"]);
+    expect(result.optional).toEqual([]);
   });
 
   test("parses mixed conditions", () => {
     const result = parseTagCondition("+fruit -admin component");
-    expect(result.required).toEqual(["fruit", "component"]);
+    expect(result.required).toEqual(["fruit"]);
     expect(result.forbidden).toEqual(["admin"]);
+    expect(result.optional).toEqual(["component"]);
   });
 
   test("handles extra whitespace", () => {
     const result = parseTagCondition("  +fruit   -admin   component  ");
-    expect(result.required).toEqual(["fruit", "component"]);
+    expect(result.required).toEqual(["fruit"]);
     expect(result.forbidden).toEqual(["admin"]);
+    expect(result.optional).toEqual(["component"]);
   });
 
   test("ignores standalone + prefix (empty tag name)", () => {
     const result = parseTagCondition("+ +fruit");
     expect(result.required).toEqual(["fruit"]);
     expect(result.forbidden).toEqual([]);
+    expect(result.optional).toEqual([]);
   });
 
   test("ignores standalone - prefix (empty tag name)", () => {
     const result = parseTagCondition("- -admin");
     expect(result.required).toEqual([]);
     expect(result.forbidden).toEqual(["admin"]);
+    expect(result.optional).toEqual([]);
   });
 
   test("handles empty string", () => {
     const result = parseTagCondition("");
     expect(result.required).toEqual([]);
     expect(result.forbidden).toEqual([]);
+    expect(result.optional).toEqual([]);
   });
 
   test("handles whitespace only", () => {
     const result = parseTagCondition("   ");
     expect(result.required).toEqual([]);
     expect(result.forbidden).toEqual([]);
+    expect(result.optional).toEqual([]);
   });
 });
 
 describe("evaluateTagCondition", () => {
   test("matches when all required tags present", () => {
-    const condition = { required: ["fruit", "red"], forbidden: [] };
+    const condition = { required: ["fruit", "red"], forbidden: [], optional: [] };
     expect(evaluateTagCondition(condition, ["fruit", "red", "apple"])).toBe(true);
   });
 
   test("fails when required tag missing", () => {
-    const condition = { required: ["fruit", "red"], forbidden: [] };
+    const condition = { required: ["fruit", "red"], forbidden: [], optional: [] };
     expect(evaluateTagCondition(condition, ["fruit", "green"])).toBe(false);
   });
 
   test("fails when forbidden tag present", () => {
-    const condition = { required: ["fruit"], forbidden: ["admin"] };
+    const condition = { required: ["fruit"], forbidden: ["admin"], optional: [] };
     expect(evaluateTagCondition(condition, ["fruit", "admin"])).toBe(false);
   });
 
   test("passes when forbidden tag absent", () => {
-    const condition = { required: ["fruit"], forbidden: ["admin"] };
+    const condition = { required: ["fruit"], forbidden: ["admin"], optional: [] };
     expect(evaluateTagCondition(condition, ["fruit", "public"])).toBe(true);
   });
 
   test("empty condition never matches (supercommentout)", () => {
-    const condition = { required: [], forbidden: [] };
+    const condition = { required: [], forbidden: [], optional: [] };
     expect(evaluateTagCondition(condition, ["any", "tags"])).toBe(false);
   });
 
   test("empty condition never matches even with empty tags", () => {
-    const condition = { required: [], forbidden: [] };
+    const condition = { required: [], forbidden: [], optional: [] };
     expect(evaluateTagCondition(condition, [])).toBe(false);
+  });
+
+  test("optional tags match if at least one is present (OR logic)", () => {
+    const condition = { required: [], forbidden: [], optional: ["scp", "tale"] };
+    expect(evaluateTagCondition(condition, ["scp"])).toBe(true);
+    expect(evaluateTagCondition(condition, ["tale"])).toBe(true);
+    expect(evaluateTagCondition(condition, ["scp", "tale"])).toBe(true);
+  });
+
+  test("optional tags fail if none is present", () => {
+    const condition = { required: [], forbidden: [], optional: ["scp", "tale"] };
+    expect(evaluateTagCondition(condition, ["joke"])).toBe(false);
+    expect(evaluateTagCondition(condition, [])).toBe(false);
+  });
+
+  test("mixed required and optional tags", () => {
+    const condition = { required: ["fruit"], forbidden: [], optional: ["red", "green"] };
+    // Has required + one optional → match
+    expect(evaluateTagCondition(condition, ["fruit", "red"])).toBe(true);
+    // Has required but no optional → no match
+    expect(evaluateTagCondition(condition, ["fruit"])).toBe(false);
+    // Has optional but not required → no match
+    expect(evaluateTagCondition(condition, ["red"])).toBe(false);
+  });
+
+  test("forbidden-only condition matches when forbidden tag absent", () => {
+    const condition = { required: [], forbidden: ["admin"], optional: [] };
+    expect(evaluateTagCondition(condition, ["fruit"])).toBe(true);
+    expect(evaluateTagCondition(condition, [])).toBe(true);
+  });
+
+  test("forbidden-only condition fails when forbidden tag present", () => {
+    const condition = { required: [], forbidden: ["admin"], optional: [] };
+    expect(evaluateTagCondition(condition, ["admin"])).toBe(false);
   });
 });

--- a/tests/unit/parser/resolve/styles-iftags.test.ts
+++ b/tests/unit/parser/resolve/styles-iftags.test.ts
@@ -138,6 +138,27 @@ describe("resolve: iftags", () => {
     expect(hasIfTags).toBe(true);
   });
 
+  it("does not collect styles from unresolved iftags", async () => {
+    const input = [
+      "[[iftags +admin]]",
+      "[[module css]]",
+      ".admin { color: red; }",
+      "[[/module]]",
+      "[[/iftags]]",
+    ].join("\n");
+    const ast = parse(input);
+    const resolved = await resolveWithoutTags(ast);
+
+    // Styles inside unresolved iftags should NOT be extracted to tree.styles
+    expect(resolved.styles).toBeUndefined();
+    // The iftags element should still contain the style element
+    const ifTagsEl = resolved.elements.find((el) => el.element === "if-tags");
+    expect(ifTagsEl).toBeDefined();
+    const ifTagsData = ifTagsEl!.data as { elements: Element[] };
+    const hasStyle = ifTagsData.elements.some((el) => el.element === "style");
+    expect(hasStyle).toBe(true);
+  });
+
   it("collects styles from resolved iftags into SyntaxTree.styles", async () => {
     const input = [
       "[[iftags +fruit]]",

--- a/tests/unit/parser/resolve/styles-iftags.test.ts
+++ b/tests/unit/parser/resolve/styles-iftags.test.ts
@@ -186,6 +186,32 @@ describe("resolve: iftags", () => {
     expect(resolved.styles).toEqual([".fruit { color: green; }"]);
   });
 
+  it("excludes elements with empty condition (supercommentout)", async () => {
+    const input = [
+      "[[iftags]]",
+      "[[module css]]",
+      "body { color: red; }",
+      "[[/module]]",
+      "Hidden content",
+      "[[/iftags]]",
+    ].join("\n");
+    const ast = parse(input);
+    const resolved = await resolveWithTags(ast, ["fruit"]);
+
+    expect(resolved.styles).toBeUndefined();
+    const text = getAllText(resolved.elements);
+    expect(text).not.toContain("Hidden content");
+  });
+
+  it("excludes elements with empty condition even with no page tags", async () => {
+    const input = "[[iftags]]\nHidden\n[[/iftags]]";
+    const ast = parse(input);
+    const resolved = await resolveWithTags(ast, []);
+
+    const text = getAllText(resolved.elements);
+    expect(text).not.toContain("Hidden");
+  });
+
   it("handles negated tag conditions", async () => {
     const input = "[[iftags -admin]]\nPublic content\n[[/iftags]]";
     const ast = parse(input);

--- a/tests/unit/parser/resolve/styles-iftags.test.ts
+++ b/tests/unit/parser/resolve/styles-iftags.test.ts
@@ -149,8 +149,9 @@ describe("resolve: iftags", () => {
     const ast = parse(input);
     const resolved = await resolveWithoutTags(ast);
 
-    // Styles inside unresolved iftags should NOT be extracted to tree.styles
-    expect(resolved.styles).toBeUndefined();
+    // tree.styles should contain only a slot placeholder, not the actual CSS
+    expect(resolved.styles).toBeDefined();
+    expect(resolved.styles!.every((s) => s.startsWith("\0"))).toBe(true);
     // The iftags element should still contain the style element
     const ifTagsEl = resolved.elements.find((el) => el.element === "if-tags");
     expect(ifTagsEl).toBeDefined();
@@ -246,8 +247,9 @@ describe("resolve: iftags", () => {
     const ast = parse(input);
     const resolved = await resolveWithoutTags(ast);
 
-    // Styles inside unresolved iftags should NOT be extracted
-    expect(resolved.styles).toBeUndefined();
+    // tree.styles should contain only a slot placeholder, not the actual CSS
+    expect(resolved.styles).toBeDefined();
+    expect(resolved.styles!.every((s) => s.startsWith("\0"))).toBe(true);
     // The iftags element should still contain the style element (inside container)
     const ifTagsEl = resolved.elements.find((el) => el.element === "if-tags");
     expect(ifTagsEl).toBeDefined();
@@ -317,6 +319,82 @@ describe("resolve: include with styles", () => {
     const resolved = await resolveWithTags(withIncludes, ["component"]);
 
     expect(resolved.styles).toEqual([".theme { background: black; }"]);
+  });
+});
+
+describe("resolve → render: CSS order consistency", () => {
+  it("produces same CSS order regardless of resolve path", async () => {
+    const { renderToHtml } = await import("@wdprlib/render");
+
+    const input = [
+      "[[module CSS]]",
+      ".top { color: blue; }",
+      "[[/module]]",
+      "[[iftags +x]]",
+      "[[module CSS]]",
+      ".conditional { color: red; }",
+      "[[/module]]",
+      "[[/iftags]]",
+    ].join("\n");
+
+    const ast = parse(input);
+
+    // Path A: resolved with tags (iftags evaluated at resolve time)
+    const resolvedWithTags = await resolveWithTags(ast, ["x"]);
+    const htmlA = renderToHtml(resolvedWithTags, {
+      page: { pageName: "p", tags: ["x"] },
+    });
+
+    // Path B: unresolved (iftags evaluated at render time)
+    const unresolved = await resolveWithoutTags(ast);
+    const htmlB = renderToHtml(unresolved, {
+      page: { pageName: "p", tags: ["x"] },
+    });
+
+    // Both paths should produce .top before .conditional
+    const topPosA = htmlA.indexOf(".top");
+    const condPosA = htmlA.indexOf(".conditional");
+    const topPosB = htmlB.indexOf(".top");
+    const condPosB = htmlB.indexOf(".conditional");
+
+    expect(topPosA).toBeLessThan(condPosA);
+    expect(topPosB).toBeLessThan(condPosB);
+  });
+
+  it("preserves CSS order with iftags before top-level style", async () => {
+    const { renderToHtml } = await import("@wdprlib/render");
+
+    const input = [
+      "[[iftags +x]]",
+      "[[module CSS]]",
+      ".conditional { color: red; }",
+      "[[/module]]",
+      "[[/iftags]]",
+      "[[module CSS]]",
+      ".bottom { color: blue; }",
+      "[[/module]]",
+    ].join("\n");
+
+    const ast = parse(input);
+
+    const resolvedWithTags = await resolveWithTags(ast, ["x"]);
+    const htmlA = renderToHtml(resolvedWithTags, {
+      page: { pageName: "p", tags: ["x"] },
+    });
+
+    const unresolved = await resolveWithoutTags(ast);
+    const htmlB = renderToHtml(unresolved, {
+      page: { pageName: "p", tags: ["x"] },
+    });
+
+    // Both paths should produce .conditional before .bottom
+    const condPosA = htmlA.indexOf(".conditional");
+    const bottomPosA = htmlA.indexOf(".bottom");
+    const condPosB = htmlB.indexOf(".conditional");
+    const bottomPosB = htmlB.indexOf(".bottom");
+
+    expect(condPosA).toBeLessThan(bottomPosA);
+    expect(condPosB).toBeLessThan(bottomPosB);
   });
 });
 

--- a/tests/unit/parser/resolve/styles-iftags.test.ts
+++ b/tests/unit/parser/resolve/styles-iftags.test.ts
@@ -233,6 +233,27 @@ describe("resolve: iftags", () => {
     expect(text).not.toContain("Hidden");
   });
 
+  it("preserves styles nested inside containers in unresolved iftags", async () => {
+    const input = [
+      "[[iftags +component]]",
+      "[[div]]",
+      "[[module css]]",
+      ".nested { color: red; }",
+      "[[/module]]",
+      "[[/div]]",
+      "[[/iftags]]",
+    ].join("\n");
+    const ast = parse(input);
+    const resolved = await resolveWithoutTags(ast);
+
+    // Styles inside unresolved iftags should NOT be extracted
+    expect(resolved.styles).toBeUndefined();
+    // The iftags element should still contain the style element (inside container)
+    const ifTagsEl = resolved.elements.find((el) => el.element === "if-tags");
+    expect(ifTagsEl).toBeDefined();
+    expect(hasStyleElements([ifTagsEl!])).toBe(true);
+  });
+
   it("handles negated tag conditions", async () => {
     const input = "[[iftags -admin]]\nPublic content\n[[/iftags]]";
     const ast = parse(input);

--- a/tests/unit/render/settings.test.ts
+++ b/tests/unit/render/settings.test.ts
@@ -234,6 +234,78 @@ describe("WikitextSettings - Renderer", () => {
       expect(html).toContain("<style>");
       expect(html).toContain("body { color: red; }");
     });
+
+    it("renders styles inside unresolved iftags (direct child)", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "if-tags",
+            data: {
+              condition: "+component",
+              elements: [
+                { element: "style", data: ".theme { color: red; }" },
+              ],
+            },
+          },
+        ],
+      };
+      const html = renderToHtml(tree, {
+        settings: pageSettings,
+        page: { pageName: "test", tags: ["component"] },
+      });
+      expect(html).toContain("<style>.theme { color: red; }</style>");
+    });
+
+    it("renders styles nested inside containers in unresolved iftags", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "if-tags",
+            data: {
+              condition: "+component",
+              elements: [
+                {
+                  element: "container",
+                  data: {
+                    type: "div",
+                    attributes: {},
+                    elements: [
+                      { element: "style", data: ".nested { margin: 0; }" },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      };
+      const html = renderToHtml(tree, {
+        settings: pageSettings,
+        page: { pageName: "test", tags: ["component"] },
+      });
+      expect(html).toContain("<style>.nested { margin: 0; }</style>");
+    });
+
+    it("does not render styles when iftags condition does not match", () => {
+      const tree: SyntaxTree = {
+        elements: [
+          {
+            element: "if-tags",
+            data: {
+              condition: "+admin",
+              elements: [
+                { element: "style", data: ".admin { color: red; }" },
+              ],
+            },
+          },
+        ],
+      };
+      const html = renderToHtml(tree, {
+        settings: pageSettings,
+        page: { pageName: "test", tags: ["component"] },
+      });
+      expect(html).not.toContain("<style>");
+    });
   });
 
   describe("default behavior (no settings specified)", () => {

--- a/tests/unit/render/settings.test.ts
+++ b/tests/unit/render/settings.test.ts
@@ -242,9 +242,7 @@ describe("WikitextSettings - Renderer", () => {
             element: "if-tags",
             data: {
               condition: "+component",
-              elements: [
-                { element: "style", data: ".theme { color: red; }" },
-              ],
+              elements: [{ element: "style", data: ".theme { color: red; }" }],
             },
           },
         ],
@@ -269,9 +267,7 @@ describe("WikitextSettings - Renderer", () => {
                   data: {
                     type: "div",
                     attributes: {},
-                    elements: [
-                      { element: "style", data: ".nested { margin: 0; }" },
-                    ],
+                    elements: [{ element: "style", data: ".nested { margin: 0; }" }],
                   },
                 },
               ],
@@ -293,9 +289,7 @@ describe("WikitextSettings - Renderer", () => {
             element: "if-tags",
             data: {
               condition: "+admin",
-              elements: [
-                { element: "style", data: ".admin { color: red; }" },
-              ],
+              elements: [{ element: "style", data: ".admin { color: red; }" }],
             },
           },
         ],


### PR DESCRIPTION
## Summary

`[[iftags]]`ブロックに関する以下のバグを修正:

- **空条件の評価不一致**: parserリゾルバの`evaluateTagCondition`が空条件で`true`を返していた（rendererは`false`）。`[[iftags]]`（supercommentout）内のCSSやコンテンツが漏出する原因
- **プレフィックスなしタグのセマンティクス不一致**: bare tag（`+`/`-`なし）をparserはAND条件、rendererはOR条件として評価していた。Wikidot仕様はOR（rendererが正しい）
- **collectStylesが未解決iftags内のスタイルを抽出**: `getPageTags`未提供時、iftags子要素のstyleが`tree.styles`に漏出し、条件に関係なくCSSが出力されていた
- **未解決iftags内のコンテナにネストされたstyleのドロップ**:
`renderInlineStyles`フラグをRenderContextに追加し、任意深度のstyleを出力可能に
- **CSS出力順の不一致**: style slot mechanism（sentinelplaceholder）を導入し、resolve済み/未resolveの両パスでCSS cascade順を一致させた
- **空タグ名トークンの扱い不一致**: `[[iftags -]]`等のプレフィックスのみトークンで、parser/renderer間の評価が異なっていた
- **STYLE_SLOT_PREFIXの依存関係修正**: `@wdprlib/render`→`@wdprlib/parser`の未宣言依存を、`@wdprlib/ast`への移動で解消