### PR TITLE
feat: バージョン別APIドキュメント対応

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,12 +6,12 @@ on:
     paths:
       - "packages/*/src/**"
       - "packages/*/README.md"
-      - "README.md"
-      - "typedoc.json"
-      - "typedoc.llms.json"
       - "packages/*/typedoc.json"
+      - "packages/*/typedoc.monorepo.json"
       - "packages/*/tsconfig.typedoc.json"
+      - "typedoc.llms.json"
       - "scripts/build-llms.ts"
+      - "scripts/build-versioned-docs.ts"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -29,12 +29,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ github.event_name == 'workflow_dispatch' && 0 || 1 }}
+          fetch-tags: ${{ github.event_name == 'workflow_dispatch' }}
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
       - run: bun install --frozen-lockfile
+
+      - name: Import versioned API docs from release tags
+        if: github.event_name == 'workflow_dispatch'
+        run: bun run docs:api:import
 
       - run: bun run docs:all
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "wdpr",
       "devDependencies": {
         "@nx/js": "^22.4.5",
-        "@r74tech/typedoc-plugin-monorepo-versions": "^1.0.0",
+        "@r74tech/typedoc-plugin-monorepo-versions": "^1.0.1",
         "@swc-node/register": "^1.11.1",
         "@swc/core": "^1.15.11",
         "@types/bun": "latest",
@@ -631,7 +631,7 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
-    "@r74tech/typedoc-plugin-monorepo-versions": ["@r74tech/typedoc-plugin-monorepo-versions@1.0.0", "", { "dependencies": { "fs-extra": "^11.2.0", "semver": "^7.6.3" }, "peerDependencies": { "typedoc": ">=0.26.0 <0.29.0" } }, "sha512-pSIzWJw2ZnPXymg/ma37c9KC97bsS1Sujh6qVcjPSK9RKSRbkIkx58bLOUvUUziGuvTknYyzXzXixezkv/haLA=="],
+    "@r74tech/typedoc-plugin-monorepo-versions": ["@r74tech/typedoc-plugin-monorepo-versions@1.0.1", "", { "dependencies": { "fs-extra": "^11.2.0", "semver": "^7.6.3" }, "peerDependencies": { "typedoc": ">=0.26.0 <0.29.0" } }, "sha512-UOae3r8d4aQzbJxjahBONjPaPymwiJJU2foAfYWF6qjHRjPRISjgPuqqL6hpGLEzc7+ta+e12zJ42+jdVAYJIQ=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "wdpr",
       "devDependencies": {
         "@nx/js": "^22.4.5",
+        "@r74tech/typedoc-plugin-monorepo-versions": "^1.0.0",
         "@swc-node/register": "^1.11.1",
         "@swc/core": "^1.15.11",
         "@types/bun": "latest",
@@ -74,11 +75,11 @@
     },
     "packages/ast": {
       "name": "@wdprlib/ast",
-      "version": "1.1.0",
+      "version": "1.2.0",
     },
     "packages/parser": {
       "name": "@wdprlib/parser",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@wdprlib/ast": "workspace:*",
@@ -86,7 +87,7 @@
     },
     "packages/render": {
       "name": "@wdprlib/render",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
         "@wdprlib/ast": "workspace:*",
         "domhandler": "^5.0.3",
@@ -630,6 +631,8 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
+    "@r74tech/typedoc-plugin-monorepo-versions": ["@r74tech/typedoc-plugin-monorepo-versions@1.0.0", "", { "dependencies": { "fs-extra": "^11.2.0", "semver": "^7.6.3" }, "peerDependencies": { "typedoc": ">=0.26.0 <0.29.0" } }, "sha512-pSIzWJw2ZnPXymg/ma37c9KC97bsS1Sujh6qVcjPSK9RKSRbkIkx58bLOUvUUziGuvTknYyzXzXixezkv/haLA=="],
+
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA=="],
 
     "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.57.0", "", { "os": "android", "cpu": "arm64" }, "sha512-sa4LyseLLXr1onr97StkU1Nb7fWcg6niokTwEVNOO7awaKaoRObQ54+V/hrF/BP1noMEaaAW6Fg2d/CfLiq3Mg=="],
@@ -936,6 +939,8 @@
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
+    "fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
@@ -949,6 +954,8 @@
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "happy-dom": ["happy-dom@20.3.9", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^4.5.0", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-OIoj0PcK2JaxQuANHxWkxFRSNXAuSgO1vCzCT66KItE0W/ieZLG+/iW8OetlxB+F9EaPB7DoFYKAubFG1f4Mvw=="],
 
@@ -1005,6 +1012,8 @@
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonc-parser": ["jsonc-parser@3.2.0", "", {}, "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="],
+
+    "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -1227,6 +1236,8 @@
     "unicode-match-property-value-ecmascript": ["unicode-match-property-value-ecmascript@2.2.1", "", {}, "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg=="],
 
     "unicode-property-aliases-ecmascript": ["unicode-property-aliases-ecmascript@2.2.0", "", {}, "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ=="],
+
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@nx/js": "^22.4.5",
-    "@r74tech/typedoc-plugin-monorepo-versions": "^1.0.0",
+    "@r74tech/typedoc-plugin-monorepo-versions": "^1.0.1",
     "@swc-node/register": "^1.11.1",
     "@swc/core": "^1.15.11",
     "@types/bun": "latest",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@nx/js": "^22.4.5",
+    "@r74tech/typedoc-plugin-monorepo-versions": "^1.0.0",
     "@swc-node/register": "^1.11.1",
     "@swc/core": "^1.15.11",
     "@types/bun": "latest",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "docs": "typedoc",
     "docs:watch": "typedoc --watch",
     "docs:llms": "typedoc --options typedoc.llms.json && bun scripts/build-llms.ts",
-    "docs:all": "bun run docs && bun run docs:llms"
+    "docs:api": "bun scripts/build-versioned-docs.ts",
+    "docs:api:import": "bun scripts/import-release-docs.ts",
+    "docs:all": "bun run docs:api && bun run docs:llms"
   },
   "devDependencies": {
     "@nx/js": "^22.4.5",

--- a/packages/ast/typedoc.monorepo.json
+++ b/packages/ast/typedoc.monorepo.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "src/index.ts"
+  ],
+  "tsconfig": "tsconfig.json",
+  "versions": {
+    "stable": "auto",
+    "dev": "auto",
+    "packageFile": "package.json",
+    "makeRelativeLinks": true,
+    "monorepo": {
+      "name": "ast",
+      "root": "../../docs/api"
+    }
+  },
+  "plugin": [
+    "@r74tech/typedoc-plugin-monorepo-versions"
+  ]
+}

--- a/packages/ast/typedoc.monorepo.json
+++ b/packages/ast/typedoc.monorepo.json
@@ -11,7 +11,7 @@
     "makeRelativeLinks": true,
     "monorepo": {
       "name": "ast",
-      "root": "../../docs/api"
+      "root": "../../docs"
     }
   },
   "plugin": [

--- a/packages/ast/typedoc.monorepo.json
+++ b/packages/ast/typedoc.monorepo.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": [
-    "src/index.ts"
-  ],
+  "entryPoints": ["src/index.ts"],
   "tsconfig": "tsconfig.json",
   "versions": {
     "stable": "auto",
@@ -14,7 +12,5 @@
       "root": "../../docs"
     }
   },
-  "plugin": [
-    "@r74tech/typedoc-plugin-monorepo-versions"
-  ]
+  "plugin": ["@r74tech/typedoc-plugin-monorepo-versions"]
 }

--- a/packages/parser/typedoc.monorepo.json
+++ b/packages/parser/typedoc.monorepo.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": [
-    "src/index.ts"
-  ],
+  "entryPoints": ["src/index.ts"],
   "tsconfig": "tsconfig.typedoc.json",
   "versions": {
     "stable": "auto",
@@ -14,7 +12,5 @@
       "root": "../../docs"
     }
   },
-  "plugin": [
-    "@r74tech/typedoc-plugin-monorepo-versions"
-  ]
+  "plugin": ["@r74tech/typedoc-plugin-monorepo-versions"]
 }

--- a/packages/parser/typedoc.monorepo.json
+++ b/packages/parser/typedoc.monorepo.json
@@ -11,7 +11,7 @@
     "makeRelativeLinks": true,
     "monorepo": {
       "name": "parser",
-      "root": "../../docs/api"
+      "root": "../../docs"
     }
   },
   "plugin": [

--- a/packages/parser/typedoc.monorepo.json
+++ b/packages/parser/typedoc.monorepo.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "src/index.ts"
+  ],
+  "tsconfig": "tsconfig.typedoc.json",
+  "versions": {
+    "stable": "auto",
+    "dev": "auto",
+    "packageFile": "package.json",
+    "makeRelativeLinks": true,
+    "monorepo": {
+      "name": "parser",
+      "root": "../../docs/api"
+    }
+  },
+  "plugin": [
+    "@r74tech/typedoc-plugin-monorepo-versions"
+  ]
+}

--- a/packages/render/typedoc.monorepo.json
+++ b/packages/render/typedoc.monorepo.json
@@ -11,7 +11,7 @@
     "makeRelativeLinks": true,
     "monorepo": {
       "name": "render",
-      "root": "../../docs/api"
+      "root": "../../docs"
     }
   },
   "plugin": [

--- a/packages/render/typedoc.monorepo.json
+++ b/packages/render/typedoc.monorepo.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": [
-    "src/index.ts"
-  ],
+  "entryPoints": ["src/index.ts"],
   "tsconfig": "tsconfig.typedoc.json",
   "versions": {
     "stable": "auto",
@@ -14,7 +12,5 @@
       "root": "../../docs"
     }
   },
-  "plugin": [
-    "@r74tech/typedoc-plugin-monorepo-versions"
-  ]
+  "plugin": ["@r74tech/typedoc-plugin-monorepo-versions"]
 }

--- a/packages/render/typedoc.monorepo.json
+++ b/packages/render/typedoc.monorepo.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "src/index.ts"
+  ],
+  "tsconfig": "tsconfig.typedoc.json",
+  "versions": {
+    "stable": "auto",
+    "dev": "auto",
+    "packageFile": "package.json",
+    "makeRelativeLinks": true,
+    "monorepo": {
+      "name": "render",
+      "root": "../../docs/api"
+    }
+  },
+  "plugin": [
+    "@r74tech/typedoc-plugin-monorepo-versions"
+  ]
+}

--- a/packages/runtime/typedoc.monorepo.json
+++ b/packages/runtime/typedoc.monorepo.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": [
-    "src/index.ts"
-  ],
+  "entryPoints": ["src/index.ts"],
   "tsconfig": "tsconfig.json",
   "versions": {
     "stable": "auto",
@@ -14,7 +12,5 @@
       "root": "../../docs"
     }
   },
-  "plugin": [
-    "@r74tech/typedoc-plugin-monorepo-versions"
-  ]
+  "plugin": ["@r74tech/typedoc-plugin-monorepo-versions"]
 }

--- a/packages/runtime/typedoc.monorepo.json
+++ b/packages/runtime/typedoc.monorepo.json
@@ -11,7 +11,7 @@
     "makeRelativeLinks": true,
     "monorepo": {
       "name": "runtime",
-      "root": "../../docs/api"
+      "root": "../../docs"
     }
   },
   "plugin": [

--- a/packages/runtime/typedoc.monorepo.json
+++ b/packages/runtime/typedoc.monorepo.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "src/index.ts"
+  ],
+  "tsconfig": "tsconfig.json",
+  "versions": {
+    "stable": "auto",
+    "dev": "auto",
+    "packageFile": "package.json",
+    "makeRelativeLinks": true,
+    "monorepo": {
+      "name": "runtime",
+      "root": "../../docs/api"
+    }
+  },
+  "plugin": [
+    "@r74tech/typedoc-plugin-monorepo-versions"
+  ]
+}

--- a/scripts/build-versioned-docs.ts
+++ b/scripts/build-versioned-docs.ts
@@ -13,7 +13,7 @@ import fs from "fs";
 const PACKAGES = ["ast", "parser", "render", "runtime"];
 const ROOT = path.resolve(import.meta.dir, "..");
 
-console.log(`Output: ${path.join(ROOT, "docs/api")}`);
+console.log(`Output: ${path.join(ROOT, "docs")}`);
 console.log(`Packages: ${PACKAGES.join(", ")}\n`);
 
 for (const pkg of PACKAGES) {

--- a/scripts/build-versioned-docs.ts
+++ b/scripts/build-versioned-docs.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+/**
+ * Build versioned API docs for each package using typedoc-plugin-monorepo-versions.
+ *
+ * Usage:
+ *   bun scripts/build-versioned-docs.ts
+ */
+
+import { $ } from "bun";
+import path from "path";
+import fs from "fs";
+
+const PACKAGES = ["ast", "parser", "render", "runtime"];
+const ROOT = path.resolve(import.meta.dir, "..");
+
+console.log(`Output: ${path.join(ROOT, "docs/api")}`);
+console.log(`Packages: ${PACKAGES.join(", ")}\n`);
+
+for (const pkg of PACKAGES) {
+	const pkgDir = path.join(ROOT, "packages", pkg);
+	const configPath = path.join(pkgDir, "typedoc.monorepo.json");
+
+	if (!fs.existsSync(configPath)) {
+		console.log(`Skipping ${pkg}: no typedoc.monorepo.json`);
+		continue;
+	}
+
+	console.log(`Building docs for ${pkg}...`);
+	const result =
+		await $`bunx typedoc --options ${configPath}`
+			.cwd(pkgDir)
+			.nothrow();
+
+	if (result.exitCode !== 0) {
+		console.error(`Failed to build docs for ${pkg} (exit code ${result.exitCode})`);
+	} else {
+		console.log(`Done: ${pkg}\n`);
+	}
+}
+
+console.log("All packages processed.");

--- a/scripts/import-release-docs.ts
+++ b/scripts/import-release-docs.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env bun
+/**
+ * Import docs from existing release tags.
+ * Checks out each release tag, builds docs for the corresponding package,
+ * then returns to the original branch.
+ *
+ * Usage:
+ *   bun scripts/import-release-docs.ts
+ *
+ * This is a one-time migration script. Run it to populate versioned docs
+ * from existing release history.
+ */
+
+import { $ } from "bun";
+import path from "path";
+import fs from "fs";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+
+// Package name mapping: tag prefix → directory name
+const PKG_MAP: Record<string, string> = {
+	"@wdprlib/ast": "ast",
+	"@wdprlib/parser": "parser",
+	"@wdprlib/render": "render",
+	"@wdprlib/runtime": "runtime",
+};
+
+// Get current branch to return to
+const currentBranch = (await $`git rev-parse --abbrev-ref HEAD`.cwd(ROOT).text()).trim();
+console.log(`Current branch: ${currentBranch}\n`);
+
+// Get all tags
+const tagsRaw = (await $`git tag -l`.cwd(ROOT).text()).trim();
+const tags = tagsRaw.split("\n").filter(Boolean);
+
+// Parse tags into package+version pairs
+const releases: { tag: string; pkg: string; version: string }[] = [];
+for (const tag of tags) {
+	for (const [prefix, dir] of Object.entries(PKG_MAP)) {
+		if (tag.startsWith(`${prefix}@`)) {
+			const version = tag.slice(prefix.length + 1);
+			releases.push({ tag, pkg: dir, version });
+		}
+	}
+}
+
+// Sort by package then version
+releases.sort((a, b) => a.pkg.localeCompare(b.pkg) || a.version.localeCompare(b.version));
+
+console.log(`Found ${releases.length} release tags:\n`);
+for (const r of releases) {
+	console.log(`  ${r.tag} → ${r.pkg}@${r.version}`);
+}
+console.log();
+
+const results: { tag: string; status: string }[] = [];
+
+for (const { tag, pkg, version } of releases) {
+	console.log(`--- ${tag} ---`);
+
+	// Checkout the tag
+	const checkout = await $`git checkout ${tag} --force`.cwd(ROOT).nothrow().quiet();
+	if (checkout.exitCode !== 0) {
+		console.error(`  Failed to checkout ${tag}`);
+		results.push({ tag, status: "checkout failed" });
+		continue;
+	}
+
+	// Install dependencies (might differ per tag)
+	const install = await $`bun install --frozen-lockfile`.cwd(ROOT).nothrow().quiet();
+	if (install.exitCode !== 0) {
+		// Try without frozen lockfile
+		await $`bun install`.cwd(ROOT).nothrow().quiet();
+	}
+
+	const pkgDir = path.join(ROOT, "packages", pkg);
+
+	// Check if source exists at this tag
+	if (!fs.existsSync(path.join(pkgDir, "src"))) {
+		console.log(`  Skipping: packages/${pkg}/src not found at ${tag}`);
+		results.push({ tag, status: "no src" });
+		continue;
+	}
+
+	// Write the monorepo config (it may not exist at this tag)
+	const configContent = JSON.stringify(
+		{
+			$schema: "https://typedoc.org/schema.json",
+			entryPoints: ["src/index.ts"],
+			tsconfig: fs.existsSync(path.join(pkgDir, "tsconfig.typedoc.json"))
+				? "tsconfig.typedoc.json"
+				: "tsconfig.json",
+			plugin: ["@r74tech/typedoc-plugin-monorepo-versions"],
+			versions: {
+				stable: "auto",
+				dev: "auto",
+				packageFile: "package.json",
+				makeRelativeLinks: true,
+				monorepo: {
+					name: pkg,
+					root: "../../docs/api",
+				},
+			},
+		},
+		null,
+		"\t",
+	);
+	const configPath = path.join(pkgDir, "typedoc.monorepo.json");
+	fs.writeFileSync(configPath, configContent);
+
+	// Build docs
+	const build =
+		await $`bunx typedoc --options ${configPath}`
+			.cwd(pkgDir)
+			.nothrow();
+
+	if (build.exitCode !== 0) {
+		console.error(`  Build failed for ${tag}`);
+		results.push({ tag, status: "build failed" });
+	} else {
+		console.log(`  Success: ${pkg}@${version}\n`);
+		results.push({ tag, status: "ok" });
+	}
+}
+
+// Return to original branch
+await $`git checkout ${currentBranch} --force`.cwd(ROOT);
+await $`bun install`.cwd(ROOT).nothrow().quiet();
+
+console.log("\n=== Results ===");
+for (const { tag, status } of results) {
+	const icon = status === "ok" ? "[OK]" : "[FAIL]";
+	console.log(`  ${icon} ${tag}: ${status}`);
+}
+
+const ok = results.filter((r) => r.status === "ok").length;
+console.log(`\n${ok}/${results.length} tags imported successfully.`);

--- a/scripts/import-release-docs.ts
+++ b/scripts/import-release-docs.ts
@@ -98,7 +98,7 @@ for (const { tag, pkg, version } of releases) {
 				makeRelativeLinks: true,
 				monorepo: {
 					name: pkg,
-					root: "../../docs/api",
+					root: "../../docs",
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- `@r74tech/typedoc-plugin-monorepo-versions` によるパッケージ別・バージョン別APIドキュメント生成を導入
- メインのtypedoc統合ドキュメントを廃止し、バージョン別API + llmsのみに変更
- docs CIでworkflow_dispatch時に過去リリースタグからのインポートを実行

## Changes
- `@r74tech/typedoc-plugin-monorepo-versions@^1.0.1` をdevDependenciesに追加
- 各パッケージに `typedoc.monorepo.json` を追加（ast, parser, render, runtime）
- `scripts/build-versioned-docs.ts`: プラグイン設定をconfigのpluginフィールドに移行
- `scripts/import-release-docs.ts`: 同上
- `docs:all` を `docs:api && docs:llms` に変更
- `.github/workflows/docs.yml`: workflow_dispatch時にimport-release-docs.tsで全タグビルド、push時はcurrent version + llmsのみ