### PR TITLE
feat(decompiler): HTML→Wikidot逆変換パッケージを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - "@wdprlib/ast@*"
       - "@wdprlib/parser@*"
       - "@wdprlib/render@*"
+      - "@wdprlib/decompiler@*"
       - "@wdprlib/runtime@*"
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Wikidot markup parser and renderer.
 | [@wdprlib/ast](./packages/ast) | AST types for Wikidot markup |
 | [@wdprlib/parser](./packages/parser) | Parser for Wikidot markup |
 | [@wdprlib/render](./packages/render) | HTML renderer for Wikidot markup |
+| [@wdprlib/decompiler](./packages/decompiler) | Decompiler for Wikidot markup |
 | [@wdprlib/runtime](./packages/runtime) | Client-side runtime for Wikidot markup |
 
 ## Installation

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,19 @@
         "typescript": "^5.9.3",
       },
     },
+    "examples/decompiler-preview": {
+      "name": "decompiler-preview",
+      "version": "0.0.0",
+      "dependencies": {
+        "@wdprlib/decompiler": "workspace:*",
+        "@wdprlib/parser": "workspace:*",
+        "@wdprlib/render": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "~5.9.3",
+        "vite": "^8.0.0-beta.13",
+      },
+    },
     "examples/wdmock-cf": {
       "name": "wdmock-cf",
       "devDependencies": {
@@ -74,11 +87,20 @@
     },
     "packages/ast": {
       "name": "@wdprlib/ast",
-      "version": "1.1.0",
+      "version": "1.2.0",
+    },
+    "packages/decompiler": {
+      "name": "@wdprlib/decompiler",
+      "version": "0.1.0",
+      "dependencies": {
+        "@wdprlib/ast": "workspace:*",
+        "domhandler": "^5.0.3",
+        "htmlparser2": "^10.0.0",
+      },
     },
     "packages/parser": {
       "name": "@wdprlib/parser",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@wdprlib/ast": "workspace:*",
@@ -86,7 +108,7 @@
     },
     "packages/render": {
       "name": "@wdprlib/render",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
         "@wdprlib/ast": "workspace:*",
         "domhandler": "^5.0.3",
@@ -522,6 +544,10 @@
 
     "@oxc-minify/binding-win32-x64-msvc": ["@oxc-minify/binding-win32-x64-msvc@0.93.0", "", { "os": "win32", "cpu": "x64" }, "sha512-FLnVjLRW3ifwHR6/87q/OQCukw+KTCR1SpcawwcykG0F62BQZjiwXpEHwNWgrV41M9Mdd52ND8/+HrMqcFlZMw=="],
 
+    "@oxc-project/runtime": ["@oxc-project/runtime@0.113.0", "", {}, "sha512-apRWH/gXeAsl/sQiblIZnLu7f8P/C9S2fJIicuHV9KOK9J7Hv1JPyTwB8WAcOrDBfjs+cbzjMOGe9UR2ue4ZQg=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.113.0", "", {}, "sha512-Tp3XmgxwNQ9pEN9vxgJBAqdRamHibi76iowQ38O2I4PMpcvNRQNVsU2n1x1nv9yh0XoTrGFzf7cZSGxmixxrhA=="],
+
     "@oxc-resolver/binding-android-arm-eabi": ["@oxc-resolver/binding-android-arm-eabi@11.16.3", "", { "os": "android", "cpu": "arm" }, "sha512-CVyWHu6ACDqDcJxR4nmGiG8vDF4TISJHqRNzac5z/gPQycs/QrP/1pDsJBy0MD7jSw8nVq2E5WqeHQKabBG/Jg=="],
 
     "@oxc-resolver/binding-android-arm64": ["@oxc-resolver/binding-android-arm64@11.16.3", "", { "os": "android", "cpu": "arm64" }, "sha512-tTIoB7plLeh2o6Ay7NnV5CJb6QUXdxI7Shnsp2ECrLSV81k+oVE3WXYrQSh4ltWL75i0OgU5Bj3bsuyg5SMepw=="],
@@ -629,6 +655,34 @@
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.4", "", { "os": "android", "cpu": "arm64" }, "sha512-vRq9f4NzvbdZavhQbjkJBx7rRebDKYR9zHfO/Wg486+I7bSecdUapzCm5cyXoK+LHokTxgSq7A5baAXUZkIz0w=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kFgEvkWLqt3YCgKB5re9RlIrx9bRsvyVUnaTakEpOPuLGzLpLapYxE9BufJNvPg8GjT6mB1alN4yN1NjzoeM8Q=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-JXmaOJGsL/+rsmMfutcDjxWM2fTaVgCHGoXS7nE8Z3c9NAYjGqHvXrAhMUZvMpHS/k7Mg+X7n/MVKb7NYWKKww=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ep3Catd6sPnHTM0P4hNEvIv5arnDvk01PfyJIJ+J3wVCG1eEaPo09tvFqdtcaTrkwQy0VWR24uz+cb4IsK53Qw=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.4", "", { "os": "linux", "cpu": "arm" }, "sha512-LwA5ayKIpnsgXJEwWc3h8wPiS33NMIHd9BhsV92T8VetVAbGe2qXlJwNVDGHN5cOQ22R9uYvbrQir2AB+ntT2w=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-AC1WsGdlV1MtGay/OQ4J9T7GRadVnpYRzTcygV1hKnypbYN20Yh4t6O1Sa2qRBMqv1etulUknqXjc3CTIsBu6A=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-lU+6rgXXViO61B4EudxtVMXSOfiZONR29Sys5VGSetUY7X8mg9FCKIIjcPPj8xNDeYzKl+H8F/qSKOBVFJChCQ=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.4", "", { "os": "linux", "cpu": "x64" }, "sha512-DZaN1f0PGp/bSvKhtw50pPsnln4T13ycDq1FrDWRiHmWt1JeW+UtYg9touPFf8yt993p8tS2QjybpzKNTxYEwg=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.4", "", { "os": "linux", "cpu": "x64" }, "sha512-RnGxwZLN7fhMMAItnD6dZ7lvy+TI7ba+2V54UF4dhaWa/p8I/ys1E73KO6HmPmgz92ZkfD8TXS1IMV8+uhbR9g=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.4", "", { "os": "none", "cpu": "arm64" }, "sha512-6lcI79+X8klGiGd8yHuTgQRjuuJYNggmEml+RsyN596P23l/zf9FVmJ7K0KVKkFAeYEdg0iMUKyIxiV5vebDNQ=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.4", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-wz7ohsKCAIWy91blZ/1FlpPdqrsm1xpcEOQVveWoL6+aSPKL4VUcoYmmzuLTssyZxRpEwzuIxL/GDsvpjaBtOw=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-cfiMrfuWCIgsFmcVG0IPuO6qTRHvF7NuG3wngX1RZzc6dU8FuBFb+J3MIR5WrdTNozlumfgL4cvz+R4ozBCvsQ=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.4", "", { "os": "win32", "cpu": "x64" }, "sha512-p6UeR9y7ht82AH57qwGuFYn69S6CZ7LLKdCKy/8T3zS9VTrJei2/CGsTUV45Da4Z9Rbhc7G4gyWQ/Ioamqn09g=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.4", "", {}, "sha512-1BrrmTu0TWfOP1riA8uakjFc9bpIUGzVKETsOtzY39pPga8zELGDl8eu1Dx7/gjM5CAz14UknsUMpBO8L+YntQ=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA=="],
 
@@ -758,6 +812,8 @@
 
     "@wdprlib/ast": ["@wdprlib/ast@workspace:packages/ast"],
 
+    "@wdprlib/decompiler": ["@wdprlib/decompiler@workspace:packages/decompiler"],
+
     "@wdprlib/parser": ["@wdprlib/parser@workspace:packages/parser"],
 
     "@wdprlib/render": ["@wdprlib/render@workspace:packages/render"],
@@ -859,6 +915,8 @@
     "cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decompiler-preview": ["decompiler-preview@workspace:examples/decompiler-preview"],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
@@ -1148,6 +1206,8 @@
 
     "restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
 
+    "rolldown": ["rolldown@1.0.0-rc.4", "", { "dependencies": { "@oxc-project/types": "=0.113.0", "@rolldown/pluginutils": "1.0.0-rc.4" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.4", "@rolldown/binding-darwin-arm64": "1.0.0-rc.4", "@rolldown/binding-darwin-x64": "1.0.0-rc.4", "@rolldown/binding-freebsd-x64": "1.0.0-rc.4", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.4", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.4", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.4", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.4", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.4", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.4", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.4", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.4", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.4" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-V2tPDUrY3WSevrvU2E41ijZlpF+5PbZu4giH+VpNraaadsJGHa4fR6IFwsocVwEXDoAdIv5qgPPxgrvKAOIPtA=="],
+
     "rollup": ["rollup@4.57.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.0", "@rollup/rollup-android-arm64": "4.57.0", "@rollup/rollup-darwin-arm64": "4.57.0", "@rollup/rollup-darwin-x64": "4.57.0", "@rollup/rollup-freebsd-arm64": "4.57.0", "@rollup/rollup-freebsd-x64": "4.57.0", "@rollup/rollup-linux-arm-gnueabihf": "4.57.0", "@rollup/rollup-linux-arm-musleabihf": "4.57.0", "@rollup/rollup-linux-arm64-gnu": "4.57.0", "@rollup/rollup-linux-arm64-musl": "4.57.0", "@rollup/rollup-linux-loong64-gnu": "4.57.0", "@rollup/rollup-linux-loong64-musl": "4.57.0", "@rollup/rollup-linux-ppc64-gnu": "4.57.0", "@rollup/rollup-linux-ppc64-musl": "4.57.0", "@rollup/rollup-linux-riscv64-gnu": "4.57.0", "@rollup/rollup-linux-riscv64-musl": "4.57.0", "@rollup/rollup-linux-s390x-gnu": "4.57.0", "@rollup/rollup-linux-x64-gnu": "4.57.0", "@rollup/rollup-linux-x64-musl": "4.57.0", "@rollup/rollup-openbsd-x64": "4.57.0", "@rollup/rollup-openharmony-arm64": "4.57.0", "@rollup/rollup-win32-arm64-msvc": "4.57.0", "@rollup/rollup-win32-ia32-msvc": "4.57.0", "@rollup/rollup-win32-x64-gnu": "4.57.0", "@rollup/rollup-win32-x64-msvc": "4.57.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA=="],
 
     "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
@@ -1294,6 +1354,8 @@
 
     "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
     "@swc-node/sourcemap-support/source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "@types/sanitize-html/htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
@@ -1301,6 +1363,8 @@
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "cosmiconfig/yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
+
+    "decompiler-preview/vite": ["vite@8.0.0-beta.14", "", { "dependencies": { "@oxc-project/runtime": "0.113.0", "fdir": "^6.5.0", "lightningcss": "^1.31.1", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rolldown": "1.0.0-rc.4", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.0.0-alpha.31", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-oLW66oi8tZcoxu6+1HFXb+5hLHco3OnEVu2Awmj5NqEo7vxaqybjBM0BXHcq+jAFhzkMGXJl8xcO5qDBczgKLg=="],
 
     "figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
@@ -1337,6 +1401,10 @@
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "decompiler-preview/vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -28,8 +28,10 @@
         "@wdprlib/decompiler": "workspace:*",
         "@wdprlib/parser": "workspace:*",
         "@wdprlib/render": "workspace:*",
+        "dompurify": "^3.3.1",
       },
       "devDependencies": {
+        "@types/dompurify": "^3.2.0",
         "typescript": "~5.9.3",
         "vite": "^8.0.0-beta.13",
       },
@@ -789,6 +791,8 @@
 
     "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
+    "@types/dompurify": ["@types/dompurify@3.2.0", "", { "dependencies": { "dompurify": "*" } }, "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
@@ -798,6 +802,8 @@
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
     "@types/sanitize-html": ["@types/sanitize-html@2.16.0", "", { "dependencies": { "htmlparser2": "^8.0.0" } }, "sha512-l6rX1MUXje5ztPT0cAFtUayXF06DqPhRyfVXareEN5gGCFaP/iwsxIyKODr9XDhfxPpN6vXUFNfo5kZMXCxBtw=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -938,6 +944,8 @@
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "dompurify": ["dompurify@3.3.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 

--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -37,6 +37,18 @@ export default defineWorkspace([
     },
   },
   {
+    name: "decompiler",
+    root: "packages/decompiler",
+    config: {
+      entry: "src/index.ts",
+      format: ["esm", "cjs"],
+      dts: true,
+      minify: false,
+      clean: true,
+      external: ["@wdprlib/ast"],
+    },
+  },
+  {
     name: "runtime",
     root: "packages/runtime",
     config: {

--- a/examples/decompiler-preview/.gitignore
+++ b/examples/decompiler-preview/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/examples/decompiler-preview/index.html
+++ b/examples/decompiler-preview/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wikidot Decompiler &amp; Preview</title>
+  </head>
+  <body>
+    <div id="app">
+      <header>
+        <h1>Wikidot Decompiler &amp; Preview</h1>
+      </header>
+      <main>
+        <section class="pane pane-input">
+          <div class="tabs">
+            <button class="tab active" data-tab="wikidot">Wikidot</button>
+            <button class="tab" data-tab="html">HTML</button>
+          </div>
+          <textarea
+            id="input-wikidot"
+            class="editor"
+            spellcheck="false"
+            placeholder="Enter Wikidot markup..."
+          >
+**Hello** //world//
+
++ Heading
+
+This is a paragraph with [[[some-page|a link]]].
+
+* List item 1
+* List item 2
+* List item 3</textarea
+          >
+          <textarea
+            id="input-html"
+            class="editor hidden"
+            spellcheck="false"
+            placeholder="Paste HTML..."
+          ></textarea>
+        </section>
+        <section class="pane pane-output">
+          <div class="tabs">
+            <button class="tab active" data-tab="preview">Preview</button>
+            <button class="tab" data-tab="decompiled">Decompiled</button>
+            <button class="tab" data-tab="ast">AST</button>
+          </div>
+          <div id="output-preview" class="output"></div>
+          <pre id="output-decompiled" class="output hidden"></pre>
+          <pre id="output-ast" class="output hidden"></pre>
+        </section>
+      </main>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/decompiler-preview/package.json
+++ b/examples/decompiler-preview/package.json
@@ -11,9 +11,11 @@
   "dependencies": {
     "@wdprlib/decompiler": "workspace:*",
     "@wdprlib/parser": "workspace:*",
-    "@wdprlib/render": "workspace:*"
+    "@wdprlib/render": "workspace:*",
+    "dompurify": "^3.3.1"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.2.0",
     "typescript": "~5.9.3",
     "vite": "^8.0.0-beta.13"
   },

--- a/examples/decompiler-preview/package.json
+++ b/examples/decompiler-preview/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "decompiler-preview",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@wdprlib/decompiler": "workspace:*",
+    "@wdprlib/parser": "workspace:*",
+    "@wdprlib/render": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "~5.9.3",
+    "vite": "^8.0.0-beta.13"
+  },
+  "overrides": {
+    "vite": "^8.0.0-beta.13"
+  }
+}

--- a/examples/decompiler-preview/src/main.ts
+++ b/examples/decompiler-preview/src/main.ts
@@ -1,0 +1,104 @@
+import "./style.css";
+import { parse } from "@wdprlib/parser";
+import { renderToHtml } from "@wdprlib/render";
+import { decompile } from "@wdprlib/decompiler";
+
+// --- Elements ---
+
+const inputWikidot = document.getElementById("input-wikidot") as HTMLTextAreaElement;
+const inputHtml = document.getElementById("input-html") as HTMLTextAreaElement;
+const outputPreview = document.getElementById("output-preview") as HTMLDivElement;
+const outputDecompiled = document.getElementById("output-decompiled") as HTMLPreElement;
+const outputAst = document.getElementById("output-ast") as HTMLPreElement;
+
+// --- Tab switching ---
+
+type InputTab = "wikidot" | "html";
+
+let activeInputTab: InputTab = "wikidot";
+
+function setupTabs(pane: Element, onSwitch: (tab: string) => void) {
+  const tabs = pane.querySelectorAll<HTMLButtonElement>(".tab");
+  tabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      tabs.forEach((t) => t.classList.remove("active"));
+      tab.classList.add("active");
+      onSwitch(tab.dataset.tab!);
+    });
+  });
+}
+
+const inputPane = document.querySelector(".pane-input")!;
+const outputPane = document.querySelector(".pane-output")!;
+
+setupTabs(inputPane, (tab) => {
+  activeInputTab = tab as InputTab;
+  inputWikidot.classList.toggle("hidden", tab !== "wikidot");
+  inputHtml.classList.toggle("hidden", tab !== "html");
+});
+
+setupTabs(outputPane, (tab) => {
+  outputPreview.classList.toggle("hidden", tab !== "preview");
+  outputDecompiled.classList.toggle("hidden", tab !== "decompiled");
+  outputAst.classList.toggle("hidden", tab !== "ast");
+});
+
+// --- Processing ---
+
+function processWikidot(source: string) {
+  try {
+    const { ast } = parse(source);
+    const html = renderToHtml(ast, { footnotes: ast.footnotes });
+
+    outputPreview.innerHTML = html;
+    outputDecompiled.textContent = decompile(html);
+    outputAst.textContent = JSON.stringify(ast, null, 2);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    outputPreview.innerHTML = `<span class="error">${escapeHtml(msg)}</span>`;
+    outputDecompiled.textContent = "";
+    outputAst.textContent = "";
+  }
+}
+
+function processHtml(html: string) {
+  try {
+    outputPreview.innerHTML = html;
+    const wikidot = decompile(html);
+    outputDecompiled.textContent = wikidot;
+
+    const { ast } = parse(wikidot);
+    outputAst.textContent = JSON.stringify(ast, null, 2);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    outputDecompiled.textContent = msg;
+    outputAst.textContent = "";
+  }
+}
+
+function update() {
+  if (activeInputTab === "wikidot") {
+    processWikidot(inputWikidot.value);
+  } else {
+    processHtml(inputHtml.value);
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// --- Debounced input ---
+
+let timer: ReturnType<typeof setTimeout>;
+
+function onInput() {
+  clearTimeout(timer);
+  timer = setTimeout(update, 200);
+}
+
+inputWikidot.addEventListener("input", onInput);
+inputHtml.addEventListener("input", onInput);
+
+// Initial render
+update();

--- a/examples/decompiler-preview/src/main.ts
+++ b/examples/decompiler-preview/src/main.ts
@@ -1,4 +1,5 @@
 import "./style.css";
+import DOMPurify from "dompurify";
 import { parse } from "@wdprlib/parser";
 import { renderToHtml } from "@wdprlib/render";
 import { decompile } from "@wdprlib/decompiler";
@@ -63,7 +64,7 @@ function processWikidot(source: string) {
 
 function processHtml(html: string) {
   try {
-    outputPreview.innerHTML = html;
+    outputPreview.innerHTML = DOMPurify.sanitize(html);
     const wikidot = decompile(html);
     outputDecompiled.textContent = wikidot;
 

--- a/examples/decompiler-preview/src/style.css
+++ b/examples/decompiler-preview/src/style.css
@@ -1,0 +1,208 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #1a1a2e;
+  --surface: #16213e;
+  --border: #0f3460;
+  --text: #e0e0e0;
+  --text-muted: #8a8a9a;
+  --accent: #e94560;
+  --tab-active: #0f3460;
+  --tab-hover: #1a2744;
+  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg);
+  color: var(--text);
+  height: 100vh;
+  overflow: hidden;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+header {
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+header h1 {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+main {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.pane {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.pane-input {
+  border-right: 1px solid var(--border);
+}
+
+.tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  flex-shrink: 0;
+}
+
+.tab {
+  padding: 8px 16px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  font-family: var(--font-sans);
+  border-bottom: 2px solid transparent;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
+}
+
+.tab:hover {
+  color: var(--text);
+  background: var(--tab-hover);
+}
+
+.tab.active {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+}
+
+.editor {
+  flex: 1;
+  width: 100%;
+  padding: 16px;
+  border: none;
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1.6;
+  resize: none;
+  outline: none;
+  tab-size: 2;
+}
+
+.editor::placeholder {
+  color: var(--text-muted);
+}
+
+.output {
+  flex: 1;
+  padding: 16px;
+  overflow: auto;
+  background: var(--surface);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+pre.output {
+  font-family: var(--font-mono);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+#output-preview {
+  font-family: var(--font-sans);
+}
+
+.hidden {
+  display: none !important;
+}
+
+/* Preview area: basic Wikidot-like styles */
+#output-preview h1,
+#output-preview h2,
+#output-preview h3,
+#output-preview h4,
+#output-preview h5,
+#output-preview h6 {
+  margin: 0.8em 0 0.4em;
+  font-weight: 600;
+}
+
+#output-preview p {
+  margin: 0.5em 0;
+}
+
+#output-preview ul,
+#output-preview ol {
+  padding-left: 1.5em;
+  margin: 0.5em 0;
+}
+
+#output-preview blockquote {
+  border-left: 3px solid var(--border);
+  padding-left: 12px;
+  margin: 0.5em 0;
+  color: var(--text-muted);
+}
+
+#output-preview table {
+  border-collapse: collapse;
+  margin: 0.5em 0;
+}
+
+#output-preview th,
+#output-preview td {
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+}
+
+#output-preview code {
+  background: rgba(255, 255, 255, 0.06);
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+
+#output-preview pre {
+  background: rgba(255, 255, 255, 0.04);
+  padding: 12px;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+#output-preview a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+#output-preview a:hover {
+  text-decoration: underline;
+}
+
+#output-preview hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 1em 0;
+}
+
+.error {
+  color: var(--accent);
+  font-style: italic;
+}

--- a/examples/decompiler-preview/tsconfig.json
+++ b/examples/decompiler-preview/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": false,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "paths": {
+      "@wdprlib/ast": ["../../packages/ast/src/index.ts"],
+      "@wdprlib/parser": ["../../packages/parser/src/index.ts"],
+      "@wdprlib/render": ["../../packages/render/src/index.ts"],
+      "@wdprlib/decompiler": ["../../packages/decompiler/src/index.ts"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -1,6 +1,6 @@
 # @wdprlib/ast
 
-AST type definitions for Wikidot markup.
+AST types for Wikidot markup.
 
 ## Installation
 
@@ -30,6 +30,7 @@ Helpers: `text`, `paragraph`, `bold`, `italics`, `heading`, `link`, `list`, `lin
 
 - [@wdprlib/parser](https://www.npmjs.com/package/@wdprlib/parser) - Wikidot markup parser
 - [@wdprlib/render](https://www.npmjs.com/package/@wdprlib/render) - HTML renderer
+- [@wdprlib/decompiler](https://www.npmjs.com/package/@wdprlib/decompiler) - HTML to Wikidot decompiler
 - [@wdprlib/runtime](https://www.npmjs.com/package/@wdprlib/runtime) - Client-side runtime
 
 ## License

--- a/packages/decompiler/CHANGELOG.md
+++ b/packages/decompiler/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/decompiler/README.md
+++ b/packages/decompiler/README.md
@@ -1,0 +1,64 @@
+# @wdprlib/decompiler
+
+Decompiler for Wikidot markup.
+
+## Installation
+
+```bash
+bun add @wdprlib/decompiler
+```
+
+## Usage
+
+```ts
+import { decompile } from "@wdprlib/decompiler";
+
+// HTML → Wikidot syntax
+const wikidot = decompile("<p><strong>Hello</strong> world</p>");
+// => "**Hello** world"
+```
+
+### Step-by-step
+
+```ts
+import { htmlToAst, serialize } from "@wdprlib/decompiler";
+
+// 1. HTML → AST
+const tree = htmlToAst("<p>Hello</p>");
+
+// 2. Inspect or transform the AST...
+
+// 3. AST → Wikidot syntax
+const wikidot = serialize(tree);
+```
+
+## API
+
+### `decompile(html, options?)`
+
+Converts HTML to Wikidot syntax in one call (HTML → AST → serialize).
+
+### `htmlToAst(html, options?)`
+
+Converts HTML to a Wikidot AST (`SyntaxTree`). Footnote content is extracted and stored in `tree.footnotes`.
+
+### `serialize(tree, options?)`
+
+Converts a Wikidot AST to markup text.
+
+## Limitations
+
+- <span style="color: #b01;">**Best-effort conversion**</span>: re-parsing the output should produce structurally equivalent HTML
+- Code block language detection from highlighted HTML is not supported
+- Modules (`[[module ...]]`), includes, iftags, comments are out of scope
+
+## Related Packages
+
+- [@wdprlib/ast](https://www.npmjs.com/package/@wdprlib/ast) - AST type definitions
+- [@wdprlib/parser](https://www.npmjs.com/package/@wdprlib/parser) - Wikidot markup parser
+- [@wdprlib/render](https://www.npmjs.com/package/@wdprlib/render) - HTML renderer
+- [@wdprlib/runtime](https://www.npmjs.com/package/@wdprlib/runtime) - Client-side runtime
+
+## License
+
+AGPL-3.0 - See [LICENSE](https://github.com/r74tech/wdpr/blob/develop/LICENSE)

--- a/packages/decompiler/package.json
+++ b/packages/decompiler/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@wdprlib/decompiler",
+  "version": "0.1.0",
+  "description": "HTML to Wikidot markup decompiler",
+  "keywords": [
+    "decompiler",
+    "html",
+    "markup",
+    "wikidot"
+  ],
+  "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/r74tech/wdpr.git",
+    "directory": "packages/decompiler"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@wdprlib/ast": "workspace:*",
+    "domhandler": "^5.0.3",
+    "htmlparser2": "^10.0.0"
+  }
+}

--- a/packages/decompiler/src/html2ast/code.ts
+++ b/packages/decompiler/src/html2ast/code.ts
@@ -1,0 +1,74 @@
+import type { Element, CodeBlockData } from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+import { isTag } from "domhandler";
+
+/**
+ * Recognize a `<div class="code">` element as a code block AST element.
+ *
+ * Handles both plain code (`<pre><code>`) and syntax-highlighted code
+ * (`<div class="hl-main"><pre>` with highlight spans).
+ */
+export function recognizeCodeBlock(node: DomElement): Element {
+  const data = extractCodeBlockData(node);
+  return { element: "code", data };
+}
+
+/**
+ * Extract code block content from a code div.
+ *
+ * For syntax-highlighted code, highlight spans are stripped to recover
+ * plain text. Language detection is not attempted (best-effort).
+ */
+function extractCodeBlockData(node: DomElement): CodeBlockData {
+  // <div class="code"><div class="hl-main"><pre>...highlighted...</pre></div></div>
+  // or <div class="code"><pre><code>...plain...</code></pre></div>
+
+  const hlMain = findByClass(node, "hl-main");
+  if (hlMain) {
+    // Syntax-highlighted: strip hl-spans and extract plain text only
+    const pre = findTag(hlMain, "pre");
+    const contents = pre ? extractPlainText(pre) : "";
+    return { contents, language: null, name: null };
+  }
+
+  const pre = findTag(node, "pre");
+  if (pre) {
+    const code = findTag(pre, "code");
+    const contents = code ? extractPlainText(code) : extractPlainText(pre);
+    return { contents, language: null, name: null };
+  }
+
+  return { contents: "", language: null, name: null };
+}
+
+/** Find a descendant element by class name (depth-first). */
+function findByClass(node: DomElement, className: string): DomElement | null {
+  for (const child of node.childNodes) {
+    if (!isTag(child)) continue;
+    if ((child.attribs.class ?? "").includes(className)) return child;
+    const found = findByClass(child, className);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Find a direct child element by tag name. */
+function findTag(node: DomElement, tagName: string): DomElement | null {
+  for (const child of node.childNodes) {
+    if (isTag(child) && child.name === tagName) return child;
+  }
+  return null;
+}
+
+/** Recursively extract plain text from a DOM subtree, ignoring all tags. */
+function extractPlainText(node: DomElement): string {
+  let result = "";
+  for (const child of node.childNodes) {
+    if (child.type === "text") {
+      result += child.data;
+    } else if (isTag(child)) {
+      result += extractPlainText(child);
+    }
+  }
+  return result;
+}

--- a/packages/decompiler/src/html2ast/collapsible.ts
+++ b/packages/decompiler/src/html2ast/collapsible.ts
@@ -1,0 +1,146 @@
+import type { Element, CollapsibleData } from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+import { isTag } from "domhandler";
+import type { DecompileContext } from "./context";
+import type { ChildrenRecognizer } from "./types-internal";
+
+/**
+ * Recognize a `<div class="collapsible-block">` element.
+ *
+ * Extracts show/hide text, open state, show-top/show-bottom flags,
+ * and the collapsible content elements.
+ */
+export function recognizeCollapsible(
+  node: DomElement,
+  _ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): Element {
+  let showText: string | null = null;
+  let hideText: string | null = null;
+  let startOpen = false;
+  let showTop = true;
+  let showBottom = false;
+  let contentElements: Element[] = [];
+
+  const folded = findByClass(node, "collapsible-block-folded");
+  const unfolded = findByClass(node, "collapsible-block-unfolded");
+
+  if (folded) {
+    // folded has display:none → start-open
+    const style = folded.attribs.style ?? "";
+    startOpen = style.includes("display:none") || style.includes("display: none");
+
+    const linkText = extractLinkText(folded);
+    if (linkText) {
+      showText = cleanCollapsibleLabel(linkText);
+    }
+  }
+
+  if (unfolded) {
+    const content = findByClass(unfolded, "collapsible-block-content");
+    if (content) {
+      contentElements = rec(content);
+    }
+
+    const linkText = extractLinkText(unfolded);
+    if (linkText) {
+      hideText = cleanCollapsibleLabel(linkText);
+    }
+
+    // Determine show-top / show-bottom from unfolded-link positions
+    const unfoldedLinks = findAllByClass(unfolded, "collapsible-block-unfolded-link");
+    if (unfoldedLinks.length === 2) {
+      showTop = true;
+      showBottom = true;
+    } else if (unfoldedLinks.length === 1) {
+      const link = unfoldedLinks[0]!;
+      const contentDiv = findByClass(unfolded, "collapsible-block-content");
+      if (contentDiv) {
+        // link before content → show-top; link after content → show-bottom
+        const linkIndex = getChildIndex(unfolded, link);
+        const contentIndex = getChildIndex(unfolded, contentDiv);
+        showTop = linkIndex < contentIndex;
+        showBottom = linkIndex > contentIndex;
+      }
+    }
+  }
+
+  // Check for default values (kept as-is for omission logic in the serializer)
+  const isDefaultShow = showText === null || showText === "+ show block";
+  const isDefaultHide = hideText === null || hideText === "- hide block";
+
+  const data: CollapsibleData = {
+    elements: contentElements,
+    attributes: {},
+    "start-open": startOpen,
+    "show-text": isDefaultShow ? null : showText,
+    "hide-text": isDefaultHide ? null : hideText,
+    "show-top": showTop,
+    "show-bottom": showBottom,
+  };
+
+  return { element: "collapsible", data };
+}
+
+/** Clean a collapsible label: normalise NBSP, strip leading +/- marker. */
+function cleanCollapsibleLabel(text: string): string {
+  return text
+    .replace(/\u00a0/g, " ")
+    .replace(/^[+–-]\s*/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Extract the text content of a `.collapsible-block-link` inside a node. */
+function extractLinkText(node: DomElement): string | null {
+  const link = findByClass(node, "collapsible-block-link");
+  if (!link) return null;
+  return getTextContent(link);
+}
+
+/** Recursively extract text content from a DOM subtree. */
+function getTextContent(node: DomElement): string {
+  let result = "";
+  for (const child of node.childNodes) {
+    if (child.type === "text") {
+      result += child.data;
+    } else if (isTag(child)) {
+      result += getTextContent(child);
+    }
+  }
+  return result;
+}
+
+/** Find the first descendant with the given class name (depth-first). */
+function findByClass(node: DomElement, className: string): DomElement | null {
+  for (const child of node.childNodes) {
+    if (!isTag(child)) continue;
+    const classes = (child.attribs.class ?? "").split(/\s+/);
+    if (classes.includes(className)) return child;
+    const found = findByClass(child, className);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Find all direct children with the given class name (non-recursive). */
+function findAllByClass(node: DomElement, className: string): DomElement[] {
+  const results: DomElement[] = [];
+  for (const child of node.childNodes) {
+    if (!isTag(child)) continue;
+    const classes = (child.attribs.class ?? "").split(/\s+/);
+    if (classes.includes(className)) results.push(child);
+    // collapsible-block-unfolded-link only appears as direct children
+  }
+  return results;
+}
+
+/** Get the index of a child among tag-only siblings. */
+function getChildIndex(parent: DomElement, child: DomElement): number {
+  let index = 0;
+  for (const c of parent.childNodes) {
+    if (c === child) return index;
+    if (isTag(c)) index++;
+  }
+  return -1;
+}

--- a/packages/decompiler/src/html2ast/container.ts
+++ b/packages/decompiler/src/html2ast/container.ts
@@ -1,0 +1,152 @@
+import type { Element, ContainerType, AttributeMap } from "@wdprlib/ast";
+import { container } from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+import type { ChildrenRecognizer } from "./types-internal";
+import { hasOnlyStyleProperty, getStyleValue, getTextContent } from "./utils";
+
+/**
+ * Create a container element with a type not included in {@link ContainerType}.
+ *
+ * The render side switches on the type as a string, so the value is valid
+ * at runtime even though it is not statically typed.
+ */
+function containerUnchecked(
+  type: string,
+  elements: Element[],
+  attributes: AttributeMap = {},
+): Element {
+  return container(type as ContainerType, elements, attributes);
+}
+
+/** Recognize a `<p>` element as a paragraph container. */
+export function recognizeParagraph(node: DomElement, rec: ChildrenRecognizer): Element {
+  const attrs = extractAttributes(node, []);
+  const elements = rec(node);
+  return container("paragraph", elements, attrs);
+}
+
+/**
+ * Recognize an inline formatting element (bold, italics, monospace, etc.).
+ *
+ * @param node - The DOM element
+ * @param type - The container type string (e.g. `"bold"`, `"italics"`)
+ * @param rec - Children recognizer
+ */
+export function recognizeInlineFormat(
+  node: DomElement,
+  type: string,
+  rec: ChildrenRecognizer,
+): Element {
+  const attrs = extractAttributes(node, ["style"]);
+  const elements = rec(node);
+  return containerUnchecked(type, elements, attrs);
+}
+
+/**
+ * Recognize a `<span>` element and map it to the appropriate AST container.
+ *
+ * Handles underline, strikethrough (via `text-decoration`), size
+ * (via `font-size`), raw text (via `white-space: pre-wrap`), and
+ * hidden/invisible spans.
+ *
+ * @returns The recognised element, or `null` if the span should fall through
+ *          to a generic span container.
+ */
+export function recognizeSpanContainer(node: DomElement, rec: ChildrenRecognizer): Element | null {
+  const style = node.attribs.style ?? "";
+
+  // text-decoration only → underline / strikethrough
+  if (hasOnlyStyleProperty(style, "text-decoration")) {
+    const value = getStyleValue(style, "text-decoration")!;
+    if (value === "underline") {
+      return recognizeInlineFormat(node, "underline", rec);
+    }
+    if (value === "line-through") {
+      return recognizeInlineFormat(node, "strikethrough", rec);
+    }
+  }
+
+  // font-size only → [[size]]
+  if (hasOnlyStyleProperty(style, "font-size")) {
+    const attrs = extractAttributes(node, []);
+    const elements = rec(node);
+    return container("size", elements, attrs);
+  }
+
+  // white-space only with pre-wrap → @@raw@@
+  if (hasOnlyStyleProperty(style, "white-space")) {
+    const value = getStyleValue(style, "white-space")!;
+    if (value === "pre-wrap") {
+      const textContent = getTextContent(node);
+      return { element: "raw", data: textContent };
+    }
+  }
+
+  // display:none / visibility:hidden → [[span style="..."]]
+  // These appear when a user explicitly sets the style, so always treat as span.
+  if (style.includes("display: none") || style.includes("display:none")) {
+    const attrs = extractAttributes(node, []);
+    const elements = rec(node);
+    return container("span", elements, attrs);
+  }
+  if (style.includes("visibility: hidden") || style.includes("visibility:hidden")) {
+    const attrs = extractAttributes(node, []);
+    const elements = rec(node);
+    return container("span", elements, attrs);
+  }
+
+  // color-only case is handled by recognizeSpanDispatch before reaching here.
+  // Multi-property spans fall through to a generic span.
+
+  const attrs = extractAttributes(node, []);
+  const elements = rec(node);
+  return container("span", elements, attrs);
+}
+
+/** Recognize a `<blockquote>` element. */
+export function recognizeBlockquote(node: DomElement, rec: ChildrenRecognizer): Element {
+  const attrs = extractAttributes(node, []);
+  const elements = rec(node);
+  return container("blockquote", elements, attrs);
+}
+
+/**
+ * Recognize a generic `<div>` element.
+ *
+ * If the div has a `text-align` style, it is treated as an alignment container.
+ * Otherwise it becomes a plain div container.
+ */
+export function recognizeDiv(node: DomElement, rec: ChildrenRecognizer): Element | null {
+  const style = node.attribs.style ?? "";
+
+  const alignMatch = style.match(/text-align:\s*(left|right|center|justify)/);
+  if (alignMatch) {
+    const align = alignMatch[1] as "left" | "right" | "center" | "justify";
+    const attrs = extractAttributes(node, ["style"]);
+    const elements = rec(node);
+    return container({ align }, elements, attrs);
+  }
+
+  const attrs = extractAttributes(node, []);
+  const elements = rec(node);
+  return container("div", elements, attrs);
+}
+
+/**
+ * Extract HTML attributes from a DOM element, filtering out excluded keys
+ * and auto-generated TOC id attributes.
+ *
+ * @param node - The DOM element
+ * @param exclude - Attribute names to exclude
+ * @returns Filtered attribute map
+ */
+export function extractAttributes(node: DomElement, exclude: string[]): AttributeMap {
+  const attrs: AttributeMap = {};
+  const excludeSet = new Set(exclude);
+  for (const [key, value] of Object.entries(node.attribs)) {
+    if (excludeSet.has(key)) continue;
+    if (key === "id" && /^toc\d+/.test(value)) continue;
+    attrs[key] = value;
+  }
+  return Object.keys(attrs).length > 0 ? attrs : {};
+}

--- a/packages/decompiler/src/html2ast/context.ts
+++ b/packages/decompiler/src/html2ast/context.ts
@@ -1,0 +1,27 @@
+import type { Element } from "@wdprlib/ast";
+import type { DecompileOptions } from "../types";
+
+/**
+ * Context maintained during HTML-to-AST decompilation.
+ *
+ * Tracks footnote content extracted from the footnotes-footer section and
+ * a running TOC index for heading id matching.
+ */
+export class DecompileContext {
+  readonly options: Required<DecompileOptions>;
+  /** Maps footnote numbers (1-based) to their parsed content elements. */
+  readonly footnoteContents: Map<number, Element[]> = new Map();
+  /** Running TOC counter for heading id matching. */
+  private tocIndex = 0;
+
+  constructor(options: DecompileOptions = {}) {
+    this.options = {
+      inlineFootnotes: options.inlineFootnotes ?? true,
+    };
+  }
+
+  /** Return the current TOC index and advance the counter. */
+  nextTocIndex(): number {
+    return this.tocIndex++;
+  }
+}

--- a/packages/decompiler/src/html2ast/footnote.ts
+++ b/packages/decompiler/src/html2ast/footnote.ts
@@ -1,0 +1,117 @@
+import type { Element } from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+import { isTag } from "domhandler";
+import type { DecompileContext } from "./context";
+import type { ChildrenRecognizer } from "./types-internal";
+
+/**
+ * Recognize a `<sup class="footnoteref">` element as a footnote-ref.
+ *
+ * Extracts the footnote number from the inner `<a>` text.
+ */
+export function recognizeFootnoteRef(node: DomElement, _ctx: DecompileContext): Element {
+  const link = findDescendantTag(node, "a");
+  const refText = link ? getTextContent(link) : "1";
+  const refNum = parseInt(refText, 10) || 1;
+  return { element: "footnote-ref", data: refNum };
+}
+
+/**
+ * Recognize a `<div class="footnotes-footer">` and extract each footnote's
+ * content into the decompilation context.
+ *
+ * Each `<div class="footnote-footer" id="footnote-N">` is parsed and its
+ * content stored in `ctx.footnoteContents` keyed by footnote number.
+ *
+ * @returns A single footnote-block element
+ */
+export function recognizeFootnotesFooter(
+  node: DomElement,
+  ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): Element[] {
+  for (const child of node.childNodes) {
+    if (!isTag(child)) continue;
+    const classes = (child.attribs.class ?? "").split(/\s+/);
+    if (!classes.includes("footnote-footer")) continue;
+
+    const id = child.attribs.id ?? "";
+    const match = id.match(/footnote-(\d+)/);
+    const num = match ? parseInt(match[1]!, 10) : 0;
+    if (num === 0) continue;
+
+    // Extract content after the <a>N</a>. prefix
+    const content = extractFootnoteContent(child, rec);
+    ctx.footnoteContents.set(num, content);
+  }
+
+  // Return as a footnote-block element
+  return [{ element: "footnote-block", data: { title: null } }];
+}
+
+/**
+ * Extract footnote body content, skipping the leading `<a>N</a>. ` prefix.
+ */
+function extractFootnoteContent(node: DomElement, rec: ChildrenRecognizer): Element[] {
+  const elements: Element[] = [];
+  let pastLink = false;
+  let pastDotSpace = false;
+
+  for (const child of node.childNodes) {
+    if (!pastLink) {
+      if (isTag(child) && child.name === "a") {
+        pastLink = true;
+        continue;
+      }
+      continue;
+    }
+
+    if (!pastDotSpace) {
+      if (child.type === "text") {
+        // Skip the ". " separator after the link number
+        const data = child.data.replace(/^\.\s*/, "");
+        if (data) {
+          elements.push({ element: "text", data });
+        }
+        pastDotSpace = true;
+        continue;
+      }
+    }
+
+    if (isTag(child)) {
+      elements.push(...rec(child));
+    } else if (child.type === "text") {
+      const data = child.data;
+      if (data.trim()) {
+        elements.push({ element: "text", data });
+      }
+    }
+  }
+
+  return elements;
+}
+
+/** Find the first descendant element with a specific tag name. */
+function findDescendantTag(node: DomElement, tagName: string): DomElement | null {
+  for (const child of node.childNodes) {
+    if (isTag(child)) {
+      if (child.name === tagName) return child;
+      const found = findDescendantTag(child, tagName);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/** Recursively extract text content from a DOM subtree. */
+function getTextContent(node: DomElement): string {
+  let result = "";
+  for (const child of node.childNodes) {
+    if (child.type === "text") {
+      result += child.data;
+    } else if (isTag(child)) {
+      result += getTextContent(child);
+    }
+  }
+  return result;
+}

--- a/packages/decompiler/src/html2ast/heading.ts
+++ b/packages/decompiler/src/html2ast/heading.ts
@@ -1,0 +1,58 @@
+import type { Element, HeadingLevel } from "@wdprlib/ast";
+import { heading } from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+import { isTag } from "domhandler";
+import type { DecompileContext } from "./context";
+import type { ChildrenRecognizer } from "./types-internal";
+
+/**
+ * Recognize an `<h1>`–`<h6>` element as a heading container.
+ *
+ * The heading level is derived from the tag name. A `toc`-prefixed `id`
+ * attribute indicates that the heading participates in the table of contents.
+ * Wikidot wraps heading content in a `<span>`, which is unwrapped here.
+ */
+export function recognizeHeading(
+  node: DomElement,
+  ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): Element {
+  const levelStr = node.name.charAt(1);
+  const level = parseInt(levelStr, 10) as HeadingLevel;
+  const id = node.attribs.id ?? "";
+  const hasToc = /^toc\d+/.test(id);
+
+  if (hasToc) {
+    ctx.nextTocIndex();
+  }
+
+  // Wikidot wraps heading content in <span>; unwrap it
+  const innerChildren = unwrapSpan(node);
+  const elements = innerChildren.flatMap((child) => {
+    if (isTag(child)) {
+      return rec(child);
+    }
+    if (child.type === "text") {
+      const data = child.data;
+      if (data.trim() === "") return [];
+      return [{ element: "text" as const, data }];
+    }
+    return [];
+  });
+
+  return heading(level, elements, hasToc);
+}
+
+/**
+ * Unwrap the `<span>` that Wikidot uses inside headings.
+ *
+ * Returns the span's children if found, otherwise the heading's direct children.
+ */
+function unwrapSpan(node: DomElement): import("domhandler").ChildNode[] {
+  for (const child of node.childNodes) {
+    if (isTag(child) && child.name === "span") {
+      return child.childNodes;
+    }
+  }
+  return node.childNodes;
+}

--- a/packages/decompiler/src/html2ast/image.ts
+++ b/packages/decompiler/src/html2ast/image.ts
@@ -1,0 +1,144 @@
+import type {
+  Element,
+  ImageSource,
+  FloatAlignment,
+  Alignment,
+  AttributeMap,
+  LinkLocation,
+} from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+import { isTag } from "domhandler";
+
+/**
+ * Recognize a standalone `<img>` element and convert it to an image AST element.
+ *
+ * Alignment and link information are inferred from the parent DOM structure.
+ */
+export function recognizeImage(node: DomElement): Element {
+  const src = node.attribs.src ?? "";
+  const source = parseImageSource(src);
+  const attrs = extractImageAttributes(node);
+  const linkLocation = findImageLink(node);
+  const alignment = findImageAlignment(node);
+
+  return {
+    element: "image",
+    data: {
+      source,
+      link: linkLocation,
+      alignment,
+      attributes: attrs,
+    },
+  };
+}
+
+/**
+ * Recognize a `<div class="image-container">` wrapper and extract its inner
+ * image as an AST element with alignment metadata.
+ *
+ * @returns The image element, or `null` if no `<img>` is found inside
+ */
+export function recognizeImageContainer(node: DomElement): Element | null {
+  const className = node.attribs.class ?? "";
+  if (!className.includes("image-container")) return null;
+
+  // Find the <img> inside the image-container
+  const img = findDescendant(node, "img");
+  if (!img) return null;
+
+  const src = img.attribs.src ?? "";
+  const source = parseImageSource(src);
+  const attrs = extractImageAttributes(img);
+  const linkLocation = findImageLink(img);
+  const alignment = parseAlignmentFromClass(className);
+
+  return {
+    element: "image",
+    data: {
+      source,
+      link: linkLocation,
+      alignment,
+      attributes: attrs,
+    },
+  };
+}
+
+/** Parse an image `src` URL into an {@link ImageSource}. */
+function parseImageSource(src: string): ImageSource {
+  if (src.startsWith("http://") || src.startsWith("https://") || src.startsWith("/")) {
+    return { type: "url", data: src };
+  }
+  return { type: "url", data: src };
+}
+
+/** Extract relevant HTML attributes from an `<img>` element. */
+function extractImageAttributes(node: DomElement): AttributeMap {
+  const attrs: AttributeMap = {};
+  if (node.attribs.alt) attrs.alt = node.attribs.alt;
+  if (node.attribs.width) attrs.width = node.attribs.width;
+  if (node.attribs.height) attrs.height = node.attribs.height;
+  if (node.attribs.class && node.attribs.class !== "image") {
+    attrs.class = node.attribs.class;
+  }
+  if (node.attribs.style) attrs.style = node.attribs.style;
+  return attrs;
+}
+
+/** Find the link URL from a parent `<a>` tag wrapping the image. */
+function findImageLink(imgNode: DomElement): LinkLocation | null {
+  const parent = imgNode.parent;
+  if (parent && isTag(parent) && parent.name === "a") {
+    const href = parent.attribs.href;
+    if (href) return href;
+  }
+  return null;
+}
+
+/**
+ * Determine image alignment from the parent DOM structure.
+ *
+ * Walks up through an optional `<a>` wrapper to find the image-container div.
+ */
+function findImageAlignment(imgNode: DomElement): FloatAlignment | null {
+  const parent = imgNode.parent;
+  if (parent && isTag(parent)) {
+    // If the parent is an <a> tag, check its parent instead
+    const containerNode = parent.name === "a" ? parent.parent : parent;
+    if (containerNode && isTag(containerNode)) {
+      const className = containerNode.attribs.class ?? "";
+      if (className.includes("image-container")) {
+        return parseAlignmentFromClass(className);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse float/alignment from a class name like `"image-container floatleft"`.
+ *
+ * @returns The alignment, or `null` if no alignment class is found
+ */
+function parseAlignmentFromClass(className: string): FloatAlignment | null {
+  const floatMatch = className.match(/float(left|right|center)/);
+  if (floatMatch) {
+    return { align: floatMatch[1] as Alignment, float: true };
+  }
+  const alignMatch = className.match(/align(left|right|center)/);
+  if (alignMatch) {
+    return { align: alignMatch[1] as Alignment, float: false };
+  }
+  return null;
+}
+
+/** Recursively find a descendant element by tag name. */
+function findDescendant(node: DomElement, tagName: string): DomElement | null {
+  for (const child of node.childNodes) {
+    if (isTag(child)) {
+      if (child.name === tagName) return child;
+      const found = findDescendant(child, tagName);
+      if (found) return found;
+    }
+  }
+  return null;
+}

--- a/packages/decompiler/src/html2ast/index.ts
+++ b/packages/decompiler/src/html2ast/index.ts
@@ -1,0 +1,34 @@
+import type { SyntaxTree, Element } from "@wdprlib/ast";
+import { parseDocument } from "htmlparser2";
+import type { DecompileOptions } from "../types";
+import { DecompileContext } from "./context";
+import { recognizeNode } from "./recognizer";
+
+/**
+ * Convert an HTML string into a Wikidot AST ({@link SyntaxTree}).
+ *
+ * The returned tree includes a `footnotes` array when footnote content is
+ * detected in the HTML.
+ *
+ * @param html - The HTML string to parse
+ * @param options - Decompilation options
+ * @returns The resulting syntax tree
+ */
+export function htmlToAst(html: string, options?: DecompileOptions): SyntaxTree {
+  const document = parseDocument(html, { decodeEntities: true });
+  const ctx = new DecompileContext(options);
+
+  const elements = document.childNodes.flatMap((node) => recognizeNode(node, ctx));
+
+  const tree: SyntaxTree = { elements };
+
+  if (ctx.footnoteContents.size > 0) {
+    const footnotes: Element[][] = [];
+    for (const [index, content] of ctx.footnoteContents) {
+      footnotes[index - 1] = content;
+    }
+    tree.footnotes = footnotes;
+  }
+
+  return tree;
+}

--- a/packages/decompiler/src/html2ast/link.ts
+++ b/packages/decompiler/src/html2ast/link.ts
@@ -1,0 +1,83 @@
+import type { Element, AnchorTarget, LinkType, LinkLabel, LinkLocation } from "@wdprlib/ast";
+import { link } from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+import type { DecompileContext } from "./context";
+import type { ChildrenRecognizer } from "./types-internal";
+
+/**
+ * Recognize an `<a>` element and convert it to the appropriate AST element.
+ *
+ * Handles anchor-name (`<a name="...">`), email links (`mailto:`), anchor
+ * links (`javascript:;`), page links (relative `/path`), and direct
+ * (external) links.
+ */
+export function recognizeLink(
+  node: DomElement,
+  _ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): Element[] {
+  const href = node.attribs.href ?? "";
+  const nameAttr = node.attribs.name;
+
+  // anchor-name: <a name="..."></a>
+  if (nameAttr && !href) {
+    return [{ element: "anchor-name", data: nameAttr }];
+  }
+
+  // email link
+  if (href.startsWith("mailto:")) {
+    const email = href.slice(7);
+    return [{ element: "email", data: email }];
+  }
+
+  const target = parseTarget(node.attribs.target);
+  const labelElements = rec(node);
+  const labelText = extractTextContent(labelElements);
+
+  // anchor link: javascript:;
+  if (href === "javascript:;") {
+    const label: LinkLabel = labelText ? { text: labelText } : { text: "" };
+    return [link(href, label, { type: "anchor", target })];
+  }
+
+  // page link: relative URL starting with /
+  if (href.startsWith("/") && !href.startsWith("//")) {
+    const pageName = href.slice(1).replace(/#.*$/, "");
+    const extra = href.includes("#") ? href.slice(href.indexOf("#")) : null;
+    const location: LinkLocation = { site: null, page: pageName };
+    const label: LinkLabel = labelText && labelText !== pageName ? { text: labelText } : "page";
+    return [link(location, label, { type: "page", extra, target })];
+  }
+
+  // direct link: external URL
+  const linkType: LinkType = "direct";
+  const label: LinkLabel = labelText && labelText !== href ? { text: labelText } : { url: href };
+  return [link(href, label, { type: linkType, target })];
+}
+
+/** Map an HTML `target` attribute value to an {@link AnchorTarget}. */
+function parseTarget(target: string | undefined): AnchorTarget | null {
+  switch (target) {
+    case "_blank":
+      return "new-tab";
+    case "_parent":
+      return "parent";
+    case "_top":
+      return "top";
+    case "_self":
+      return "same";
+    default:
+      return null;
+  }
+}
+
+/** Extract concatenated plain text from a flat array of AST elements. */
+function extractTextContent(elements: Element[]): string {
+  let result = "";
+  for (const el of elements) {
+    if (el.element === "text") {
+      result += el.data;
+    }
+  }
+  return result;
+}

--- a/packages/decompiler/src/html2ast/list.ts
+++ b/packages/decompiler/src/html2ast/list.ts
@@ -1,0 +1,147 @@
+import type { Element, ListType, ListItem, ListData, DefinitionListItem } from "@wdprlib/ast";
+import { list, listItemElements, listItemSubList } from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+import { isTag } from "domhandler";
+import type { DecompileContext } from "./context";
+import type { ChildrenRecognizer } from "./types-internal";
+
+/**
+ * Recognize a `<ul>` or `<ol>` element as a list AST element.
+ *
+ * @param node - The list DOM element
+ * @param ctx - Decompilation context
+ * @param rec - Children recognizer
+ */
+export function recognizeList(
+  node: DomElement,
+  ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): Element {
+  const type: ListType = node.name === "ol" ? "numbered" : "bullet";
+  const items = recognizeListItems(node, ctx, rec);
+  return list(type, items);
+}
+
+/** Collect all `<li>` children and convert them to list items. */
+function recognizeListItems(
+  node: DomElement,
+  ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): ListItem[] {
+  const items: ListItem[] = [];
+  for (const child of node.childNodes) {
+    if (!isTag(child)) continue;
+    if (child.name === "li") {
+      items.push(recognizeListItem(child, ctx, rec));
+    }
+  }
+  return items;
+}
+
+/**
+ * Recognize a single `<li>` element.
+ *
+ * If the `<li>` contains a nested `<ul>`/`<ol>`, it becomes a sub-list item.
+ * When text precedes the sub-list, both are combined into a single item.
+ */
+function recognizeListItem(
+  node: DomElement,
+  ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): ListItem {
+  // Check for nested sub-list
+  for (const child of node.childNodes) {
+    if (isTag(child) && (child.name === "ul" || child.name === "ol")) {
+      const subType: ListType = child.name === "ol" ? "numbered" : "bullet";
+      const subItems = recognizeListItems(child, ctx, rec);
+      const subData: ListData = { type: subType, attributes: {}, items: subItems };
+
+      // Check for text elements preceding the sub-list
+      const precedingElements = collectPrecedingElements(node, child, rec);
+      if (precedingElements.length > 0) {
+        // Text + sub-list: use text as the main item content
+        return listItemElements([
+          ...precedingElements,
+          { element: "list", data: subData } as Element,
+        ]);
+      }
+      return listItemSubList(subData);
+    }
+  }
+
+  const elements = rec(node);
+  return listItemElements(elements);
+}
+
+/**
+ * Collect AST elements from the children of a node that appear before
+ * the given stop element (typically a nested list).
+ */
+function collectPrecedingElements(
+  parent: DomElement,
+  stopAt: DomElement,
+  rec: ChildrenRecognizer,
+): Element[] {
+  const elements: Element[] = [];
+  for (const child of parent.childNodes) {
+    if (child === stopAt) break;
+    if (isTag(child)) {
+      if (child.name !== "ul" && child.name !== "ol") {
+        elements.push(...rec(child));
+      }
+    } else if (child.type === "text") {
+      const data = child.data.trim();
+      if (data) {
+        elements.push({ element: "text", data: child.data });
+      }
+    }
+  }
+  return elements;
+}
+
+/**
+ * Recognize a `<dl>` element as a definition-list AST element.
+ *
+ * Pairs consecutive `<dt>` (key) and `<dd>` (value) elements.
+ */
+export function recognizeDefinitionList(
+  node: DomElement,
+  _ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): Element {
+  const items: DefinitionListItem[] = [];
+  let currentKey: Element[] = [];
+  let currentKeyString = "";
+
+  for (const child of node.childNodes) {
+    if (!isTag(child)) continue;
+    if (child.name === "dt") {
+      currentKey = rec(child);
+      currentKeyString = extractText(child);
+    } else if (child.name === "dd") {
+      const value = rec(child);
+      items.push({
+        key_string: currentKeyString,
+        key: currentKey,
+        value,
+      });
+      currentKey = [];
+      currentKeyString = "";
+    }
+  }
+
+  return { element: "definition-list", data: items };
+}
+
+/** Recursively extract plain text content from a DOM element. */
+function extractText(node: DomElement): string {
+  let result = "";
+  for (const child of node.childNodes) {
+    if (child.type === "text") {
+      result += child.data;
+    } else if (isTag(child)) {
+      result += extractText(child);
+    }
+  }
+  return result;
+}

--- a/packages/decompiler/src/html2ast/math.ts
+++ b/packages/decompiler/src/html2ast/math.ts
@@ -1,0 +1,60 @@
+import type { Element, MathData, MathInlineData } from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+import { isTag } from "domhandler";
+
+/**
+ * Recognize a `<div class="math-block">` element as a block math AST element.
+ *
+ * The LaTeX source is extracted from the `<code class="math-source">` child.
+ * An optional `data-name` attribute is preserved for equation references.
+ */
+export function recognizeMathBlock(node: DomElement): Element {
+  const source = findMathSource(node);
+  const name = node.attribs["data-name"] ?? null;
+
+  const data: MathData = {
+    name,
+    "latex-source": source,
+  };
+
+  return { element: "math", data };
+}
+
+/**
+ * Recognize a `<span class="math-inline">` element as an inline math AST element.
+ *
+ * The LaTeX source is extracted from the `<code class="math-source">` child.
+ */
+export function recognizeMathInline(node: DomElement): Element {
+  const source = findMathSource(node);
+
+  const data: MathInlineData = {
+    "latex-source": source,
+  };
+
+  return { element: "math-inline", data };
+}
+
+/** Find and extract the text content of a `<code class="math-source">` child. */
+function findMathSource(node: DomElement): string {
+  for (const child of node.childNodes) {
+    if (!isTag(child)) continue;
+    if (child.name === "code" && (child.attribs.class ?? "").includes("math-source")) {
+      return getTextContent(child);
+    }
+  }
+  return "";
+}
+
+/** Recursively extract text content from a DOM subtree. */
+function getTextContent(node: DomElement): string {
+  let result = "";
+  for (const child of node.childNodes) {
+    if (child.type === "text") {
+      result += child.data;
+    } else if (isTag(child)) {
+      result += getTextContent(child);
+    }
+  }
+  return result;
+}

--- a/packages/decompiler/src/html2ast/misc.ts
+++ b/packages/decompiler/src/html2ast/misc.ts
@@ -1,0 +1,127 @@
+import type { Element, ClearFloat, ColorData, IframeData, Embed } from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+import { isTag } from "domhandler";
+import type { DecompileContext } from "./context";
+import type { ChildrenRecognizer } from "./types-internal";
+
+/**
+ * Recognize a `<span style="color: ...;">` element as a color AST element.
+ *
+ * The color value is extracted from the inline style.
+ */
+export function recognizeColor(
+  node: DomElement,
+  _ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): Element {
+  const style = node.attribs.style ?? "";
+  const match = style.match(/color:\s*([^;]+)/);
+  const color = match ? match[1]!.trim() : "inherit";
+  const elements = rec(node);
+
+  const data: ColorData = { color, elements };
+  return { element: "color", data };
+}
+
+/**
+ * Recognize a clear-float div (`<div style="clear:both; ...">`)
+ * as a clear-float AST element.
+ *
+ * @returns The clear-float element, or `null` if the style does not contain `clear:`
+ */
+export function recognizeClearFloat(node: DomElement): Element | null {
+  const style = node.attribs.style ?? "";
+  if (!style.includes("clear:") && !style.includes("clear :")) return null;
+
+  let direction: ClearFloat = "both";
+  if (style.includes("clear:left") || style.includes("clear: left")) {
+    direction = "left";
+  } else if (style.includes("clear:right") || style.includes("clear: right")) {
+    direction = "right";
+  }
+
+  return { element: "clear-float", data: direction };
+}
+
+/**
+ * Recognize an embed container (`<div class="embed-youtube">`, etc.)
+ * as an embed AST element.
+ *
+ * @returns The embed element, or `null` if the class is not a known embed type
+ */
+export function recognizeEmbed(node: DomElement): Element | null {
+  const className = node.attribs.class ?? "";
+
+  if (className.includes("embed-youtube")) {
+    const iframe = findDescendantTag(node, "iframe");
+    if (!iframe) return null;
+    const src = iframe.attribs.src ?? "";
+    const match = src.match(/youtube\.com\/embed\/([a-zA-Z0-9_-]+)/);
+    if (!match) return null;
+    const data: Embed = { embed: "youtube", data: { "video-id": match[1]! } };
+    return { element: "embed", data };
+  }
+
+  if (className.includes("embed-vimeo")) {
+    const iframe = findDescendantTag(node, "iframe");
+    if (!iframe) return null;
+    const src = iframe.attribs.src ?? "";
+    const match = src.match(/vimeo\.com\/video\/([a-zA-Z0-9_-]+)/);
+    if (!match) return null;
+    const data: Embed = { embed: "vimeo", data: { "video-id": match[1]! } };
+    return { element: "embed", data };
+  }
+
+  return null;
+}
+
+/**
+ * Recognize an `<iframe>` element as an iframe AST element.
+ *
+ * Only a subset of safe attributes (width, height, scrolling, frameborder,
+ * class, style) are preserved.
+ */
+export function recognizeIframe(node: DomElement): Element {
+  const url = node.attribs.src ?? "";
+  const attrs: Record<string, string> = {};
+  const allowedAttrs = ["width", "height", "scrolling", "frameborder", "class", "style"];
+  for (const attr of allowedAttrs) {
+    if (node.attribs[attr]) {
+      attrs[attr] = node.attribs[attr]!;
+    }
+  }
+
+  const data: IframeData = { url, attributes: attrs };
+  return { element: "iframe", data };
+}
+
+/** Recognize a `<style>` element as a style AST element. */
+export function recognizeStyle(node: DomElement): Element {
+  const content = getTextContent(node);
+  return { element: "style", data: content };
+}
+
+/** Find the first descendant element with a specific tag name. */
+function findDescendantTag(node: DomElement, tagName: string): DomElement | null {
+  for (const child of node.childNodes) {
+    if (isTag(child)) {
+      if (child.name === tagName) return child;
+      const found = findDescendantTag(child, tagName);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/** Recursively extract text content from a DOM subtree. */
+function getTextContent(node: DomElement): string {
+  let result = "";
+  for (const child of node.childNodes) {
+    if (child.type === "text") {
+      result += child.data;
+    } else if (isTag(child)) {
+      result += getTextContent(child);
+    }
+  }
+  return result;
+}

--- a/packages/decompiler/src/html2ast/recognizer.ts
+++ b/packages/decompiler/src/html2ast/recognizer.ts
@@ -1,0 +1,272 @@
+import type { Element } from "@wdprlib/ast";
+import { isTag, isText, type ChildNode, type Element as DomElement } from "domhandler";
+import type { DecompileContext } from "./context";
+import type { ChildrenRecognizer } from "./types-internal";
+import { recognizeText, recognizeLineBreak, recognizeHorizontalRule } from "./text";
+import {
+  recognizeParagraph,
+  recognizeInlineFormat,
+  recognizeSpanContainer,
+  recognizeBlockquote,
+  recognizeDiv,
+} from "./container";
+import { recognizeHeading } from "./heading";
+import { recognizeLink } from "./link";
+import { recognizeImage, recognizeImageContainer } from "./image";
+import { recognizeList, recognizeDefinitionList } from "./list";
+import { recognizeTable } from "./table";
+import { recognizeCodeBlock } from "./code";
+import { recognizeCollapsible } from "./collapsible";
+import { recognizeTabView } from "./tab-view";
+import { recognizeFootnoteRef, recognizeFootnotesFooter } from "./footnote";
+import { recognizeMathBlock, recognizeMathInline } from "./math";
+import {
+  recognizeColor,
+  recognizeClearFloat,
+  recognizeEmbed,
+  recognizeIframe,
+  recognizeStyle,
+} from "./misc";
+import { hasOnlyStyleProperty } from "./utils";
+
+/**
+ * Convert a single DOM node (text or element) into zero or more AST elements.
+ *
+ * Whitespace-only text nodes are normalised: nodes containing a space or NBSP
+ * become a single space (inline separator), while nodes containing only
+ * newlines/tabs are dropped (structural whitespace between blocks).
+ */
+export function recognizeNode(node: ChildNode, ctx: DecompileContext): Element[] {
+  if (isText(node)) {
+    const data = node.data;
+    if (/^\s*$/.test(data)) {
+      // Contains a space or NBSP → keep as inline separator
+      // Only newlines/tabs → drop as structural whitespace between blocks
+      if (/[ \u00a0]/.test(data)) {
+        return [recognizeText(" ")];
+      }
+      return [];
+    }
+    return [recognizeText(data)];
+  }
+
+  if (!isTag(node)) return [];
+
+  return recognizeElement(node, ctx);
+}
+
+/**
+ * Dispatch a DOM element to the appropriate recognizer based on its tag name.
+ *
+ * @param node - The DOM element to recognise
+ * @param ctx - Decompilation context
+ * @returns Recognised AST elements
+ */
+export function recognizeElement(node: DomElement, ctx: DecompileContext): Element[] {
+  const rec: ChildrenRecognizer = (n) => recognizeChildren(n, ctx);
+  const className = node.attribs.class ?? "";
+
+  switch (node.name) {
+    case "p": {
+      const iframe = findDirectChild(node, "iframe");
+      if (iframe) return [recognizeIframe(iframe)];
+      return [recognizeParagraph(node, rec)];
+    }
+    case "br":
+      return [recognizeLineBreak()];
+    case "hr":
+      return [recognizeHorizontalRule()];
+
+    // headings
+    case "h1":
+    case "h2":
+    case "h3":
+    case "h4":
+    case "h5":
+    case "h6":
+      return [recognizeHeading(node, ctx, rec)];
+
+    // inline formatting
+    case "strong":
+    case "b":
+      return [recognizeInlineFormat(node, "bold", rec)];
+    case "em":
+    case "i":
+      return [recognizeInlineFormat(node, "italics", rec)];
+    case "sup":
+      if (className.includes("footnoteref")) {
+        return [recognizeFootnoteRef(node, ctx)];
+      }
+      return [recognizeInlineFormat(node, "superscript", rec)];
+    case "sub":
+      return [recognizeInlineFormat(node, "subscript", rec)];
+    case "tt":
+      return [recognizeInlineFormat(node, "monospace", rec)];
+    case "mark":
+      return [recognizeInlineFormat(node, "mark", rec)];
+    case "ins":
+      return [recognizeInlineFormat(node, "insertion", rec)];
+    case "del":
+      return [recognizeInlineFormat(node, "deletion", rec)];
+    case "ruby":
+      return [recognizeInlineFormat(node, "ruby", rec)];
+    case "rt":
+      return [recognizeInlineFormat(node, "ruby-text", rec)];
+
+    // span
+    case "span":
+      return recognizeSpanDispatch(node, ctx, rec);
+
+    // links
+    case "a":
+      return recognizeLink(node, ctx, rec);
+
+    // images
+    case "img":
+      return [recognizeImage(node)];
+
+    // block elements
+    case "blockquote":
+      return [recognizeBlockquote(node, rec)];
+
+    case "div":
+      return recognizeDivDispatch(node, ctx, rec);
+
+    // lists
+    case "ul":
+    case "ol":
+      return [recognizeList(node, ctx, rec)];
+    case "dl":
+      return [recognizeDefinitionList(node, ctx, rec)];
+
+    // table
+    case "table":
+      return [recognizeTable(node, ctx, rec)];
+
+    // iframe
+    case "iframe":
+      return [recognizeIframe(node)];
+
+    // style
+    case "style":
+      return [recognizeStyle(node)];
+
+    default:
+      return recognizeChildren(node, ctx);
+  }
+}
+
+/**
+ * Dispatch a `<span>` element to the correct recognizer.
+ *
+ * Checks for math-inline, color-only style, and generic span containers
+ * in priority order.
+ */
+function recognizeSpanDispatch(
+  node: DomElement,
+  ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): Element[] {
+  const className = node.attribs.class ?? "";
+  const style = node.attribs.style ?? "";
+
+  // math-inline
+  if (className.includes("math-inline")) {
+    return [recognizeMathInline(node)];
+  }
+
+  // color property only → ##color|text##
+  if (hasOnlyStyleProperty(style, "color")) {
+    return [recognizeColor(node, ctx, rec)];
+  }
+
+  const result = recognizeSpanContainer(node, rec);
+  if (result) return [result];
+  return rec(node);
+}
+
+/**
+ * Dispatch a `<div>` element to the correct recognizer.
+ *
+ * Checks for code blocks, collapsibles, tabviews, image containers,
+ * footnotes-footer, math blocks, embeds, clear-floats, and generic divs
+ * in priority order.
+ */
+function recognizeDivDispatch(
+  node: DomElement,
+  ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): Element[] {
+  const className = node.attribs.class ?? "";
+  const style = node.attribs.style ?? "";
+
+  // code block
+  if (className === "code" || className.startsWith("code ")) {
+    return [recognizeCodeBlock(node)];
+  }
+
+  // collapsible
+  if (className.includes("collapsible-block") && !className.includes("collapsible-block-")) {
+    return [recognizeCollapsible(node, ctx, rec)];
+  }
+
+  // tabview
+  if (className.includes("yui-navset")) {
+    return [recognizeTabView(node, ctx, rec)];
+  }
+
+  // image container
+  if (className.includes("image-container")) {
+    const img = recognizeImageContainer(node);
+    if (img) return [img];
+  }
+
+  // footnotes-footer
+  if (className.includes("footnotes-footer")) {
+    return recognizeFootnotesFooter(node, ctx, rec);
+  }
+
+  // math-block
+  if (className.includes("math-block")) {
+    return [recognizeMathBlock(node)];
+  }
+
+  // embed
+  if (className.includes("embed-")) {
+    const embed = recognizeEmbed(node);
+    if (embed) return [embed];
+  }
+
+  // clear-float
+  if (style.includes("clear:") || style.includes("clear :")) {
+    const cf = recognizeClearFloat(node);
+    if (cf) return [cf];
+  }
+
+  const result = recognizeDiv(node, rec);
+  if (result) return [result];
+  return recognizeChildren(node, ctx);
+}
+
+/** Find a direct child element by tag name. */
+function findDirectChild(node: DomElement, tagName: string): DomElement | null {
+  for (const child of node.childNodes) {
+    if (isTag(child) && child.name === tagName) return child;
+  }
+  return null;
+}
+
+/**
+ * Recursively recognise all child nodes of a DOM element.
+ *
+ * @param node - Parent DOM element
+ * @param ctx - Decompilation context
+ * @returns Flat array of recognised AST elements
+ */
+export function recognizeChildren(node: DomElement, ctx: DecompileContext): Element[] {
+  const elements: Element[] = [];
+  for (const child of node.childNodes) {
+    elements.push(...recognizeNode(child, ctx));
+  }
+  return elements;
+}

--- a/packages/decompiler/src/html2ast/tab-view.ts
+++ b/packages/decompiler/src/html2ast/tab-view.ts
@@ -1,0 +1,84 @@
+import type { Element, TabData } from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+import { isTag } from "domhandler";
+import type { DecompileContext } from "./context";
+import type { ChildrenRecognizer } from "./types-internal";
+
+/**
+ * Recognize a `<div class="yui-navset">` element as a tab-view AST element.
+ *
+ * Tab labels are extracted from `<ul class="yui-nav">` and tab content from
+ * `<div class="yui-content">`.
+ */
+export function recognizeTabView(
+  node: DomElement,
+  _ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): Element {
+  const labels: string[] = [];
+  const tabs: TabData[] = [];
+
+  // Extract labels: <ul class="yui-nav"><li><a><em>label</em></a></li></ul>
+  const nav = findByClass(node, "yui-nav");
+  if (nav) {
+    for (const li of nav.childNodes) {
+      if (!isTag(li) || li.name !== "li") continue;
+      const em = findDescendantTag(li, "em");
+      if (em) {
+        labels.push(getTextContent(em));
+      }
+    }
+  }
+
+  // Extract content: <div class="yui-content"><div>content</div>...</div>
+  const content = findByClass(node, "yui-content");
+  if (content) {
+    let tabIndex = 0;
+    for (const child of content.childNodes) {
+      if (!isTag(child) || child.name !== "div") continue;
+      const label = labels[tabIndex] ?? `Tab ${tabIndex + 1}`;
+      const elements = rec(child);
+      tabs.push({ label, elements });
+      tabIndex++;
+    }
+  }
+
+  return { element: "tab-view", data: tabs };
+}
+
+/** Find the first descendant with the given class name (depth-first). */
+function findByClass(node: DomElement, className: string): DomElement | null {
+  for (const child of node.childNodes) {
+    if (!isTag(child)) continue;
+    const classes = (child.attribs.class ?? "").split(/\s+/);
+    if (classes.includes(className)) return child;
+    const found = findByClass(child, className);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Find the first descendant element with a specific tag name. */
+function findDescendantTag(node: DomElement, tagName: string): DomElement | null {
+  for (const child of node.childNodes) {
+    if (isTag(child)) {
+      if (child.name === tagName) return child;
+      const found = findDescendantTag(child, tagName);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/** Recursively extract text content from a DOM subtree. */
+function getTextContent(node: DomElement): string {
+  let result = "";
+  for (const child of node.childNodes) {
+    if (child.type === "text") {
+      result += child.data;
+    } else if (isTag(child)) {
+      result += getTextContent(child);
+    }
+  }
+  return result;
+}

--- a/packages/decompiler/src/html2ast/table.ts
+++ b/packages/decompiler/src/html2ast/table.ts
@@ -1,0 +1,88 @@
+import type { Element, TableData, TableRow, TableCell, Alignment } from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+import { isTag } from "domhandler";
+import type { DecompileContext } from "./context";
+import type { ChildrenRecognizer } from "./types-internal";
+
+/**
+ * Recognize a `<table>` element as an AST table element.
+ *
+ * Handles `<thead>`, `<tbody>`, `<tfoot>` wrappers and bare `<tr>` rows.
+ */
+export function recognizeTable(
+  node: DomElement,
+  _ctx: DecompileContext,
+  rec: ChildrenRecognizer,
+): Element {
+  const rows: TableRow[] = [];
+
+  // Look inside <tbody>/<thead>/<tfoot> if present
+  const rowContainers = findRowContainers(node);
+  for (const container of rowContainers) {
+    for (const child of container.childNodes) {
+      if (!isTag(child) || child.name !== "tr") continue;
+      rows.push(recognizeRow(child, rec));
+    }
+  }
+
+  const data: TableData = {
+    attributes: {},
+    rows,
+  };
+
+  return { element: "table", data };
+}
+
+/**
+ * Find the containers that hold `<tr>` rows.
+ *
+ * Returns `<thead>`, `<tbody>`, `<tfoot>` elements when present, or the
+ * table element itself if rows are direct children.
+ */
+function findRowContainers(table: DomElement): DomElement[] {
+  const containers: DomElement[] = [];
+  for (const child of table.childNodes) {
+    if (!isTag(child)) continue;
+    if (child.name === "tbody" || child.name === "thead" || child.name === "tfoot") {
+      containers.push(child);
+    } else if (child.name === "tr") {
+      containers.push(table);
+      return containers;
+    }
+  }
+  if (containers.length === 0) containers.push(table);
+  return containers;
+}
+
+/** Recognize a `<tr>` element as a table row. */
+function recognizeRow(node: DomElement, rec: ChildrenRecognizer): TableRow {
+  const cells: TableCell[] = [];
+  for (const child of node.childNodes) {
+    if (!isTag(child)) continue;
+    if (child.name === "td" || child.name === "th") {
+      cells.push(recognizeCell(child, rec));
+    }
+  }
+  return { attributes: {}, cells };
+}
+
+/** Recognize a `<td>` or `<th>` element as a table cell. */
+function recognizeCell(node: DomElement, rec: ChildrenRecognizer): TableCell {
+  const header = node.name === "th";
+  const colspanStr = node.attribs.colspan;
+  const columnSpan = colspanStr ? parseInt(colspanStr, 10) : 1;
+
+  const style = node.attribs.style ?? "";
+  const alignMatch = style.match(/text-align:\s*(left|right|center|justify)/);
+  const align: Alignment | null = alignMatch ? (alignMatch[1] as Alignment) : null;
+
+  const elements = rec(node);
+
+  return {
+    header,
+    "column-span": columnSpan,
+    align,
+    attributes: {},
+    elements,
+  };
+}

--- a/packages/decompiler/src/html2ast/text.ts
+++ b/packages/decompiler/src/html2ast/text.ts
@@ -1,0 +1,17 @@
+import type { Element } from "@wdprlib/ast";
+import { text, lineBreak, horizontalRule } from "@wdprlib/ast";
+
+/** Recognize a text node and return an AST text element. */
+export function recognizeText(data: string): Element {
+  return text(data);
+}
+
+/** Recognize a `<br>` tag and return an AST line-break element. */
+export function recognizeLineBreak(): Element {
+  return lineBreak();
+}
+
+/** Recognize an `<hr>` tag and return an AST horizontal-rule element. */
+export function recognizeHorizontalRule(): Element {
+  return horizontalRule();
+}

--- a/packages/decompiler/src/html2ast/types-internal.ts
+++ b/packages/decompiler/src/html2ast/types-internal.ts
@@ -1,0 +1,5 @@
+import type { Element } from "@wdprlib/ast";
+import type { Element as DomElement } from "domhandler";
+
+/** Function signature that converts child DOM nodes into AST elements. */
+export type ChildrenRecognizer = (node: DomElement) => Element[];

--- a/packages/decompiler/src/html2ast/utils.ts
+++ b/packages/decompiler/src/html2ast/utils.ts
@@ -1,0 +1,69 @@
+import type { Element as DomElement } from "domhandler";
+
+interface StyleProperty {
+  property: string;
+  value: string;
+}
+
+/**
+ * Parse a CSS style string into an array of property–value pairs.
+ *
+ * @param style - Raw CSS style attribute value (e.g. `"color: red; font-size: 12px;"`)
+ * @returns Parsed property–value pairs
+ */
+export function parseStyleProperties(style: string): StyleProperty[] {
+  return style
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((s) => {
+      const colonIndex = s.indexOf(":");
+      if (colonIndex === -1) return null;
+      return {
+        property: s.slice(0, colonIndex).trim(),
+        value: s.slice(colonIndex + 1).trim(),
+      };
+    })
+    .filter((p): p is StyleProperty => p !== null);
+}
+
+/**
+ * Check whether a CSS style string contains exactly one property matching
+ * the given name.
+ *
+ * @example
+ * hasOnlyStyleProperty("font-size: 20px", "font-size")          // true
+ * hasOnlyStyleProperty("font-size: 20px; color: red", "font-size") // false
+ */
+export function hasOnlyStyleProperty(style: string, property: string): boolean {
+  const props = parseStyleProperties(style);
+  return props.length === 1 && props[0]?.property === property;
+}
+
+/**
+ * Extract the value of a specific CSS property from a style string.
+ *
+ * @returns The property value, or `null` if not found
+ */
+export function getStyleValue(style: string, property: string): string | null {
+  const props = parseStyleProperties(style);
+  const found = props.find((p) => p.property === property);
+  return found?.value ?? null;
+}
+
+/**
+ * Recursively extract the text content of a DOM node.
+ *
+ * `&nbsp;` (U+00A0) is normalised to a regular space.
+ */
+export function getTextContent(node: DomElement): string {
+  let result = "";
+  for (const child of node.childNodes) {
+    if (child.type === "text") {
+      result += child.data;
+    } else if ("childNodes" in child) {
+      result += getTextContent(child as DomElement);
+    }
+  }
+  return result.replace(/\u00a0/g, " ");
+}

--- a/packages/decompiler/src/index.ts
+++ b/packages/decompiler/src/index.ts
@@ -1,0 +1,23 @@
+import type { SyntaxTree } from "@wdprlib/ast";
+import type { DecompileOptions } from "./types";
+import { htmlToAst } from "./html2ast/index";
+import { serialize } from "./serializer/index";
+
+export type { DecompileOptions, SerializeOptions } from "./types";
+export { htmlToAst } from "./html2ast/index";
+export { serialize } from "./serializer/index";
+
+/**
+ * Decompile HTML into Wikidot syntax.
+ *
+ * Combines {@link htmlToAst} and {@link serialize} into a single call:
+ * HTML → AST → Wikidot markup.
+ *
+ * @param html - The HTML string to decompile
+ * @param options - Decompilation options
+ * @returns Wikidot syntax string
+ */
+export function decompile(html: string, options?: DecompileOptions): string {
+  const tree: SyntaxTree = htmlToAst(html, options);
+  return serialize(tree);
+}

--- a/packages/decompiler/src/serializer/code.ts
+++ b/packages/decompiler/src/serializer/code.ts
@@ -1,0 +1,29 @@
+import type { CodeBlockData } from "@wdprlib/ast";
+import type { SerializeContext } from "./context";
+
+/**
+ * Serialize a code block element to `[[code]]...[[/code]]` syntax.
+ *
+ * Includes `type` and `name` attributes when present.
+ */
+export function serializeCode(ctx: SerializeContext, data: CodeBlockData): void {
+  const attrs: string[] = [];
+  if (data.language) {
+    attrs.push(`type="${data.language}"`);
+  }
+  if (data.name) {
+    attrs.push(`name="${data.name}"`);
+  }
+
+  const attrStr = attrs.length > 0 ? " " + attrs.join(" ") : "";
+
+  ctx.pushBlockLine(`[[code${attrStr}]]`);
+  if (data.contents.length > 0) {
+    ctx.push(data.contents);
+    if (!data.contents.endsWith("\n")) {
+      ctx.push(ctx.newline);
+    }
+  }
+  ctx.pushBlockLine("[[/code]]");
+  ctx.requestBlankLine();
+}

--- a/packages/decompiler/src/serializer/collapsible.ts
+++ b/packages/decompiler/src/serializer/collapsible.ts
@@ -1,0 +1,42 @@
+import type { CollapsibleData } from "@wdprlib/ast";
+import { SerializeContext } from "./context";
+import { serializeElements } from "./serialize-element";
+
+/**
+ * Serialize a collapsible element to `[[collapsible]]...[[/collapsible]]` syntax.
+ *
+ * Attributes (`show`, `hide`, `folded`, `hideLocation`) are emitted only
+ * when they differ from the Wikidot defaults.
+ */
+export function serializeCollapsible(ctx: SerializeContext, data: CollapsibleData): void {
+  const attrs: string[] = [];
+
+  if (data["show-text"]) {
+    attrs.push(`show="${data["show-text"]}"`);
+  }
+  if (data["hide-text"]) {
+    attrs.push(`hide="${data["hide-text"]}"`);
+  }
+  if (data["start-open"]) {
+    attrs.push(`folded="no"`);
+  }
+
+  // hideLocation: default is show-top=true, show-bottom=false (= "top")
+  if (!data["show-top"] && !data["show-bottom"]) {
+    attrs.push(`hideLocation="neither"`);
+  } else if (!data["show-top"] && data["show-bottom"]) {
+    attrs.push(`hideLocation="bottom"`);
+  } else if (data["show-top"] && data["show-bottom"]) {
+    attrs.push(`hideLocation="both"`);
+  }
+  // show-top=true, show-bottom=false is the default → no attribute needed
+
+  const attrStr = attrs.length > 0 ? " " + attrs.join(" ") : "";
+
+  ctx.pushBlockLine(`[[collapsible${attrStr}]]`);
+  const innerCtx = new SerializeContext({ newline: ctx.newline });
+  serializeElements(innerCtx, data.elements);
+  ctx.push(innerCtx.getBlockInnerOutput());
+  ctx.pushBlockLine("[[/collapsible]]");
+  ctx.requestBlankLine();
+}

--- a/packages/decompiler/src/serializer/container.ts
+++ b/packages/decompiler/src/serializer/container.ts
@@ -218,8 +218,14 @@ function serializeBlockSpan(
 /**
  * Serialize a div container.
  *
- * Uses `div_` (paragraph-strip) when the first child is an inline element,
- * and `div` (normal) when the first child is block-level.
+ * Uses `div_` (paragraph-strip) when the first or last child is inline text
+ * content (indicating `unwrapEdgeParagraphs` was applied), and `div` (normal)
+ * otherwise.
+ *
+ * Only text-like inline elements (text, line-break, inline formatting, links,
+ * etc.) trigger `div_`. Non-text inline elements like `image` do not, because
+ * they can appear without `<p>` wrapping in `[[div]]` too (e.g. Wikidot
+ * renders `[[image]]` inside `[[div]]` without a `<p>` wrapper).
  */
 function serializeDivContainer(
   ctx: SerializeContext,
@@ -228,8 +234,10 @@ function serializeDivContainer(
 ): void {
   const attrStr = formatAttributes(attributes);
 
-  // div_ detection: first child is inline (not a paragraph) → paragraph-strip
-  const isParagraphStrip = elements.length > 0 && !isBlockLevelElement(elements[0]!);
+  // div_ detection: first or last child is inline text content → paragraph-strip
+  const isParagraphStrip =
+    elements.length > 0 &&
+    (isInlineTextElement(elements[0]!) || isInlineTextElement(elements[elements.length - 1]!));
 
   const openTag = isParagraphStrip ? "div_" : "div";
   ctx.pushBlockLine(`[[${openTag}${attrStr}]]`);
@@ -277,7 +285,7 @@ function serializeDivStripInner(parentCtx: SerializeContext, elements: Element[]
   return innerCtx.getBlockInnerOutput();
 }
 
-/** Check whether an AST element is block-level (for div_ detection). */
+/** Check whether an AST element is block-level (used by serializeDivStripInner). */
 function isBlockLevelElement(el: Element): boolean {
   switch (el.element) {
     case "container": {
@@ -305,6 +313,59 @@ function isBlockLevelElement(el: Element): boolean {
     case "math":
     case "bibliography-block":
       return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Check whether an AST element is inline text content (for div_ detection).
+ *
+ * Returns true for elements that would normally be inside a `<p>` tag.
+ * Their direct presence as a div child indicates paragraph stripping (div_).
+ *
+ * Non-text inline elements like `image` return false because they can
+ * appear without `<p>` wrapping in `[[div]]` too.
+ */
+function isInlineTextElement(el: Element): boolean {
+  switch (el.element) {
+    case "text":
+    case "line-break":
+    case "line-breaks":
+    case "raw":
+    case "variable":
+    case "email":
+    case "link":
+    case "anchor":
+    case "anchor-name":
+    case "footnote":
+    case "footnote-ref":
+    case "bibliography-cite":
+    case "user":
+    case "date":
+    case "color":
+    case "math-inline":
+    case "equation-reference":
+    case "expr":
+      return true;
+    case "container": {
+      const type = (el.data as ContainerData)?.type;
+      if (typeof type === "string") {
+        switch (type) {
+          case "bold":
+          case "italics":
+          case "underline":
+          case "strikethrough":
+          case "superscript":
+          case "subscript":
+          case "monospace":
+          case "span":
+          case "size":
+            return true;
+        }
+      }
+      return false;
+    }
     default:
       return false;
   }

--- a/packages/decompiler/src/serializer/container.ts
+++ b/packages/decompiler/src/serializer/container.ts
@@ -1,0 +1,398 @@
+import type { ContainerData, Alignment, Element } from "@wdprlib/ast";
+import { isHeaderType, isAlignType, isStringContainerType } from "@wdprlib/ast";
+import { SerializeContext } from "./context";
+import { serializeElement, serializeElements } from "./serialize-element";
+
+/**
+ * Serialize a container element by dispatching on its type.
+ *
+ * Handles headings, alignment blocks, string-typed containers (paragraph,
+ * bold, italics, etc.), and extended types (mark, insertion, deletion, ruby).
+ */
+export function serializeContainer(ctx: SerializeContext, data: ContainerData): void {
+  const { type, elements, attributes } = data;
+
+  if (isHeaderType(type)) {
+    serializeHeading(ctx, type.header.level, type.header["has-toc"], elements);
+    return;
+  }
+
+  if (isAlignType(type)) {
+    serializeAlignment(ctx, type.align, elements);
+    return;
+  }
+
+  if (isStringContainerType(type)) {
+    serializeStringContainer(ctx, type, elements, attributes);
+    return;
+  }
+
+  // Extended types (mark, insertion, deletion, ruby, ruby-text)
+  const typeStr = type as unknown as string;
+  switch (typeStr) {
+    case "mark":
+    case "insertion":
+    case "deletion":
+      serializeSpanLike(ctx, typeStr, elements, attributes);
+      return;
+    case "ruby":
+      serializeElements(ctx, elements);
+      return;
+    case "ruby-text":
+      serializeElements(ctx, elements);
+      return;
+    default:
+      serializeElements(ctx, elements);
+  }
+}
+
+/**
+ * Serialize a heading container using `+` prefix syntax.
+ *
+ * Uses inline serialization so the heading content is on a single line.
+ */
+function serializeHeading(
+  ctx: SerializeContext,
+  level: number,
+  hasToc: boolean,
+  elements: Element[],
+): void {
+  const prefix = "+".repeat(level);
+  const tocMarker = hasToc ? "" : "*";
+  ctx.pushBlockLine(prefix + tocMarker + " " + serializeInline(ctx, elements));
+  ctx.requestBlankLine();
+}
+
+/**
+ * Serialize an alignment container to `[[=]]...[[/=]]` (or `>`, `<`, `==`) syntax.
+ */
+function serializeAlignment(ctx: SerializeContext, align: Alignment, elements: Element[]): void {
+  const tag = alignTag(align);
+  ctx.pushBlockLine(`[[${tag}]]`);
+  const inner = serializeBlockInner(ctx, elements);
+  ctx.push(inner);
+  ctx.pushBlockLine(`[[/${tag}]]`);
+  ctx.requestBlankLine();
+}
+
+/** Map an alignment value to its Wikidot tag character(s). */
+function alignTag(align: Alignment): string {
+  switch (align) {
+    case "center":
+      return "=";
+    case "right":
+      return ">";
+    case "left":
+      return "<";
+    case "justify":
+      return "==";
+  }
+}
+
+/**
+ * Serialize a string-typed container (paragraph, bold, italics, underline,
+ * strikethrough, superscript, subscript, monospace, span, div, blockquote, size).
+ */
+function serializeStringContainer(
+  ctx: SerializeContext,
+  type: string,
+  elements: Element[],
+  attributes: Record<string, string>,
+): void {
+  switch (type) {
+    case "paragraph": {
+      // Single-line centering: style="text-align: center;" → = text
+      const style = attributes.style ?? "";
+      const prevInParagraph = ctx.inParagraph;
+      ctx.inParagraph = true;
+      if (style === "text-align: center;") {
+        ctx.pushBlockLine("= " + serializeInline(ctx, elements));
+        ctx.requestParagraphBlankLine();
+      } else {
+        serializeElements(ctx, elements);
+        ctx.push(ctx.newline);
+        ctx.requestParagraphBlankLine();
+      }
+      ctx.inParagraph = prevInParagraph;
+      break;
+    }
+    case "bold":
+      ctx.push("**");
+      serializeElements(ctx, elements);
+      ctx.push("**");
+      break;
+    case "italics":
+      ctx.push("//");
+      serializeElements(ctx, elements);
+      ctx.push("//");
+      break;
+    case "underline":
+      ctx.push("__");
+      serializeElements(ctx, elements);
+      ctx.push("__");
+      break;
+    case "strikethrough":
+      ctx.push("--");
+      serializeElements(ctx, elements);
+      ctx.push("--");
+      break;
+    case "superscript":
+      ctx.push("^^");
+      serializeElements(ctx, elements);
+      ctx.push("^^");
+      break;
+    case "subscript":
+      ctx.push(",,");
+      serializeElements(ctx, elements);
+      ctx.push(",,");
+      break;
+    case "monospace":
+      ctx.push("{{");
+      serializeElements(ctx, elements);
+      ctx.push("}}");
+      break;
+    case "span":
+      if (!ctx.inParagraph) {
+        serializeBlockSpan(ctx, elements, attributes);
+      } else {
+        serializeSpanLike(ctx, "span", elements, attributes);
+      }
+      break;
+    case "div":
+      serializeDivContainer(ctx, elements, attributes);
+      break;
+    case "blockquote":
+      serializeBlockquote(ctx, elements);
+      break;
+    case "size":
+      serializeSizeContainer(ctx, elements, attributes);
+      break;
+    default:
+      serializeElements(ctx, elements);
+  }
+}
+
+/**
+ * Serialize a span-like container to `[[span attrs]]content[[/span]]` syntax.
+ *
+ * For non-span types (mark, insertion, deletion), the type is set as
+ * the `class` attribute.
+ */
+function serializeSpanLike(
+  ctx: SerializeContext,
+  type: string,
+  elements: Element[],
+  attributes: Record<string, string>,
+): void {
+  const attrs = { ...attributes };
+  if (type !== "span") {
+    attrs.class = type;
+  }
+  const attrStr = formatAttributes(attrs);
+  ctx.push(`[[span${attrStr}]]`);
+  serializeElements(ctx, elements);
+  ctx.push("[[/span]]");
+}
+
+/**
+ * Serialize a block-level span_ (outside paragraphs).
+ *
+ * The inner content is serialized in an inline (paragraph) context to
+ * prevent nested spans from becoming block-level span_.
+ */
+function serializeBlockSpan(
+  ctx: SerializeContext,
+  elements: Element[],
+  attributes: Record<string, string>,
+): void {
+  const attrStr = formatAttributes(attributes);
+  // Serialize content in inline context (nested spans stay inline, not span_)
+  const innerCtx = new SerializeContext({ newline: ctx.newline });
+  innerCtx.inParagraph = true;
+  serializeElements(innerCtx, elements);
+  const content = innerCtx.getOutput().replace(/\n$/, "");
+  ctx.pushBlockLine(`[[span_${attrStr}]]${content}[[/span]]`);
+  ctx.requestParagraphBlankLine();
+}
+
+/**
+ * Serialize a div container.
+ *
+ * Uses `div_` (paragraph-strip) when the first child is an inline element,
+ * and `div` (normal) when the first child is block-level.
+ */
+function serializeDivContainer(
+  ctx: SerializeContext,
+  elements: Element[],
+  attributes: Record<string, string>,
+): void {
+  const attrStr = formatAttributes(attributes);
+
+  // div_ detection: first child is inline (not a paragraph) → paragraph-strip
+  const isParagraphStrip = elements.length > 0 && !isBlockLevelElement(elements[0]!);
+
+  const openTag = isParagraphStrip ? "div_" : "div";
+  ctx.pushBlockLine(`[[${openTag}${attrStr}]]`);
+
+  if (isParagraphStrip) {
+    const inner = serializeDivStripInner(ctx, elements);
+    ctx.push(inner);
+  } else {
+    const inner = serializeBlockInner(ctx, elements);
+    ctx.push(inner);
+  }
+
+  ctx.pushBlockLine("[[/div]]");
+  ctx.requestBlankLine();
+}
+
+/**
+ * Serialize the content of a `div_` (paragraph-strip) container.
+ *
+ * Consecutive inline elements are treated as implicit paragraphs.
+ * Block elements are serialized normally.
+ */
+function serializeDivStripInner(parentCtx: SerializeContext, elements: Element[]): string {
+  const innerCtx = new SerializeContext({ newline: parentCtx.newline });
+
+  let i = 0;
+  while (i < elements.length) {
+    const el = elements[i]!;
+
+    if (isBlockLevelElement(el)) {
+      // Block element: serialize directly (handles its own newlines)
+      serializeElement(innerCtx, el);
+      i++;
+    } else {
+      // Consecutive inline elements → implicit paragraph
+      while (i < elements.length && !isBlockLevelElement(elements[i]!)) {
+        serializeElement(innerCtx, elements[i]!);
+        i++;
+      }
+      innerCtx.push(innerCtx.newline);
+      innerCtx.requestParagraphBlankLine();
+    }
+  }
+
+  return innerCtx.getBlockInnerOutput();
+}
+
+/** Check whether an AST element is block-level (for div_ detection). */
+function isBlockLevelElement(el: Element): boolean {
+  switch (el.element) {
+    case "container": {
+      const type = (el.data as ContainerData)?.type;
+      if (typeof type === "object") return true; // header, alignment
+      if (typeof type === "string") {
+        return type === "paragraph" || type === "div" || type === "blockquote";
+      }
+      return false;
+    }
+    case "list":
+    case "definition-list":
+    case "table":
+    case "horizontal-rule":
+    case "clear-float":
+    case "code":
+    case "collapsible":
+    case "tab-view":
+    case "footnote-block":
+    case "style":
+    case "embed":
+    case "embed-block":
+    case "iframe":
+    case "content-separator":
+    case "math":
+    case "bibliography-block":
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Serialize a blockquote container.
+ *
+ * Each line of the inner content is prefixed with `> `. Nested blockquotes
+ * concatenate `>` characters (e.g. `>>` for depth 2). Blank lines within
+ * the blockquote use `> ` to preserve paragraph breaks.
+ */
+function serializeBlockquote(ctx: SerializeContext, elements: Element[]): void {
+  const innerCtx = new SerializeContext({ newline: ctx.newline });
+  innerCtx.insideBlockquote = true;
+  serializeElements(innerCtx, elements);
+  const inner = innerCtx.getBlockInnerOutput();
+  const lines = inner.split(ctx.newline);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (i === lines.length - 1 && line === "") break;
+    // Nested blockquote: concatenate > characters (> > → >>)
+    if (line.startsWith(">")) {
+      ctx.pushBlockLine(`>${line}`);
+    } else if (line === "") {
+      // Empty line → `> ` to preserve paragraph break
+      ctx.pushBlockLine("> ");
+    } else {
+      ctx.pushBlockLine(`> ${line}`);
+    }
+  }
+  // Suppress blank line after blockquote when inside another blockquote
+  // (paragraph→paragraph uses requestParagraphBlankLine; paragraph→block needs none)
+  if (!ctx.insideBlockquote) {
+    ctx.requestBlankLine();
+  }
+}
+
+/** Serialize a size container to `[[size value]]content[[/size]]` syntax. */
+function serializeSizeContainer(
+  ctx: SerializeContext,
+  elements: Element[],
+  attributes: Record<string, string>,
+): void {
+  const style = attributes.style ?? "";
+  const match = style.match(/font-size:\s*([^;]+)/);
+  const size = match ? match[1]!.trim() : "1em";
+  ctx.push(`[[size ${size}]]`);
+  serializeElements(ctx, elements);
+  ctx.push("[[/size]]");
+}
+
+/**
+ * Serialize child elements inside a block container, stripping trailing
+ * blank lines from the output.
+ */
+function serializeBlockInner(parentCtx: SerializeContext, elements: Element[]): string {
+  const innerCtx = new SerializeContext({ newline: parentCtx.newline });
+  serializeElements(innerCtx, elements);
+  return innerCtx.getBlockInnerOutput();
+}
+
+/** Serialize inline elements to a string (stripping trailing newline). */
+function serializeInline(parentCtx: SerializeContext, elements: Element[]): string {
+  const innerCtx = new SerializeContext({ newline: parentCtx.newline });
+  serializeElements(innerCtx, elements);
+  return innerCtx.getOutput().replace(/\n$/, "");
+}
+
+/**
+ * Format an attribute map to a Wikidot attribute string.
+ *
+ * Attributes starting with `_` are internal and excluded. The `u-` prefix
+ * on id attributes is stripped (Wikidot adds it during rendering).
+ */
+function formatAttributes(attributes: Record<string, string>): string {
+  const entries = Object.entries(attributes).filter(([k]) => !k.startsWith("_"));
+  if (entries.length === 0) return "";
+  return (
+    " " +
+    entries
+      .map(([k, v]) => {
+        // Strip the u- prefix from id attributes
+        if (k === "id" && v.startsWith("u-")) {
+          return `${k}="${v.slice(2)}"`;
+        }
+        return `${k}="${v}"`;
+      })
+      .join(" ")
+  );
+}

--- a/packages/decompiler/src/serializer/context.ts
+++ b/packages/decompiler/src/serializer/context.ts
@@ -1,0 +1,130 @@
+import type { SerializeOptions } from "../types";
+
+/**
+ * The two tiers of pending blank line.
+ *
+ * - `"none"` – no blank line pending
+ * - `"paragraph"` – blank line requested after a paragraph (cleared by block elements)
+ * - `"block"` – blank line requested after a block element (always emitted)
+ */
+type BlankLineType = "none" | "paragraph" | "block";
+
+/**
+ * Mutable context used during AST-to-Wikidot serialization.
+ *
+ * Manages an output buffer and a two-tier pending-blank-line system that
+ * ensures correct spacing between paragraphs and block-level constructs.
+ */
+export class SerializeContext {
+  readonly newline: string;
+  /** Force `_\n` line-break syntax inside lists and definition lists. */
+  forceLineBreakSyntax = false;
+  /** Suppress extra blank lines after nested blockquotes. */
+  insideBlockquote = false;
+  /** When `true`, spans are emitted inline; when `false`, as block-level `span_`. */
+  inParagraph = false;
+  private buffer: string[] = [];
+  private atLineStart = true;
+  private _pendingBlankLine: BlankLineType = "none";
+
+  constructor(options: SerializeOptions = {}) {
+    this.newline = options.newline ?? "\n";
+  }
+
+  /**
+   * Request a blank line after a block element.
+   *
+   * The blank line is emitted when the next content is pushed via
+   * {@link push} or {@link pushBlockLine}.
+   */
+  requestBlankLine(): void {
+    this._pendingBlankLine = "block";
+  }
+
+  /**
+   * Request a blank line after a paragraph.
+   *
+   * Unlike {@link requestBlankLine}, this is cleared (not emitted) when
+   * a block element follows via {@link pushBlockLine}, because no blank
+   * line is needed between a paragraph and a subsequent block element.
+   */
+  requestParagraphBlankLine(): void {
+    // Do not downgrade an existing block-level request
+    if (this._pendingBlankLine === "none") {
+      this._pendingBlankLine = "paragraph";
+    }
+  }
+
+  /** Emit the pending blank line if one exists (any tier). */
+  flushPendingBlankLine(): void {
+    if (this._pendingBlankLine !== "none") {
+      this.buffer.push(this.newline);
+      this._pendingBlankLine = "none";
+    }
+  }
+
+  /** Discard the pending blank line without emitting it. */
+  clearPendingBlankLine(): void {
+    this._pendingBlankLine = "none";
+  }
+
+  get hasPendingBlankLine(): boolean {
+    return this._pendingBlankLine !== "none";
+  }
+
+  /** Push inline content. Any pending blank line is emitted first. */
+  push(text: string): void {
+    this.flushPendingBlankLine();
+    this.buffer.push(text);
+    this.atLineStart = text.endsWith(this.newline);
+  }
+
+  /**
+   * Push a complete block line (content + newline).
+   *
+   * A block-tier pending blank line is flushed; a paragraph-tier pending
+   * blank line is cleared (paragraph → block needs no separator).
+   */
+  pushBlockLine(text: string): void {
+    if (this._pendingBlankLine === "block") {
+      this.flushPendingBlankLine();
+    } else {
+      this.clearPendingBlankLine();
+    }
+    this.buffer.push(text + this.newline);
+    this.atLineStart = true;
+  }
+
+  /** Push a line (content + newline) as inline content. */
+  pushLine(text: string): void {
+    this.push(text + this.newline);
+  }
+
+  /** Push a blank line as inline content. */
+  pushBlankLine(): void {
+    this.push(this.newline);
+  }
+
+  /** Whether the cursor is currently at the start of a line. */
+  isAtLineStart(): boolean {
+    return this.atLineStart;
+  }
+
+  /** Return the full serialized output. */
+  getOutput(): string {
+    return this.buffer.join("");
+  }
+
+  /**
+   * Return the serialized output for use inside a block container,
+   * with trailing double-newlines collapsed to a single newline.
+   */
+  getBlockInnerOutput(): string {
+    let output = this.getOutput();
+    const nl = this.newline;
+    while (output.endsWith(nl + nl)) {
+      output = output.slice(0, -nl.length);
+    }
+    return output;
+  }
+}

--- a/packages/decompiler/src/serializer/footnote.ts
+++ b/packages/decompiler/src/serializer/footnote.ts
@@ -1,0 +1,134 @@
+import type { FootnoteBlockData, Element } from "@wdprlib/ast";
+import { SerializeContext } from "./context";
+import { serializeElement, serializeElements } from "./serialize-element";
+
+/**
+ * Serialize a void footnote element (inline restoration).
+ *
+ * Uses `footnoteCounter` to identify which footnote content to insert,
+ * pulling from `tree.footnotes`.
+ *
+ * @param ctx - Serialization context
+ * @param index - Zero-based footnote counter index
+ * @param footnotes - Footnote content arrays from the syntax tree
+ */
+export function serializeFootnoteInline(
+  ctx: SerializeContext,
+  index: number,
+  footnotes?: Element[][],
+): void {
+  const content = footnotes?.[index];
+  if (content && content.length > 0) {
+    serializeFootnoteContent(ctx, content);
+  } else {
+    ctx.push("[[footnote]][[/footnote]]");
+  }
+}
+
+/**
+ * Serialize a footnote-ref element (numbered reference) inline.
+ *
+ * @param ctx - Serialization context
+ * @param refNum - 1-based footnote reference number
+ * @param footnotes - Footnote content arrays from the syntax tree
+ */
+export function serializeFootnoteRef(
+  ctx: SerializeContext,
+  refNum: number,
+  footnotes?: Element[][],
+): void {
+  const content = footnotes?.[refNum - 1];
+  if (content && content.length > 0) {
+    serializeFootnoteContent(ctx, content);
+  } else {
+    ctx.push("[[footnote]][[/footnote]]");
+  }
+}
+
+/**
+ * Serialize footnote content to `[[footnote]]...[[/footnote]]` syntax.
+ *
+ * The parser stores the first paragraph as bare elements and subsequent
+ * paragraphs as paragraph containers. When paragraph containers are present,
+ * a blank line (paragraph separator) is inserted between the bare elements
+ * and the first paragraph container.
+ */
+function serializeFootnoteContent(ctx: SerializeContext, content: Element[]): void {
+  // Check whether the content contains paragraph containers
+  const hasParagraph = content.some(
+    (el) => el.element === "container" && el.data?.type === "paragraph",
+  );
+
+  if (hasParagraph) {
+    // Separate bare elements (first paragraph) from paragraph containers
+    const innerCtx = new SerializeContext({ newline: ctx.newline });
+    let seenParagraph = false;
+    for (const el of content) {
+      if (el.element === "container" && el.data?.type === "paragraph" && !seenParagraph) {
+        // First paragraph container after bare elements → insert blank line separator
+        seenParagraph = true;
+        innerCtx.push(innerCtx.newline);
+        innerCtx.pushBlankLine();
+      }
+      serializeElement(innerCtx, el);
+    }
+    const inner = innerCtx.getBlockInnerOutput();
+
+    ctx.push("[[footnote]]" + ctx.newline);
+    ctx.push(inner);
+    if (!inner.endsWith(ctx.newline)) {
+      ctx.push(ctx.newline);
+    }
+    ctx.push("[[/footnote]]");
+  } else {
+    // No paragraph containers → buffer and decide single-line vs multi-line
+    const innerCtx = new SerializeContext({ newline: ctx.newline });
+    serializeElements(innerCtx, content);
+    const inner = innerCtx.getBlockInnerOutput();
+
+    if (inner.includes(ctx.newline)) {
+      ctx.push("[[footnote]]" + ctx.newline);
+      ctx.push(inner);
+      if (!inner.endsWith(ctx.newline)) {
+        ctx.push(ctx.newline);
+      }
+      ctx.push("[[/footnote]]");
+    } else {
+      ctx.push(`[[footnote]]${inner}[[/footnote]]`);
+    }
+  }
+}
+
+/**
+ * Serialize a footnote-block element to `[[footnoteblock]]` syntax.
+ *
+ * The parser implicitly appends a default footnote-block at the end of the
+ * document. If this block is the last element and has no custom attributes,
+ * it is skipped (the parser will re-add it on re-parse).
+ *
+ * @param ctx - Serialization context
+ * @param data - Footnote block data
+ * @param isLastElement - Whether this is the last element in the tree
+ */
+export function serializeFootnoteBlock(
+  ctx: SerializeContext,
+  data: FootnoteBlockData,
+  isLastElement?: boolean,
+): void {
+  // Skip the implicit default footnote-block:
+  // last element AND default attributes → treated as implicit
+  // (explicit default footnoteblocks like footnote/block-empty are
+  // indistinguishable from implicit ones — lossy)
+  if (!data.title && !data.hide && isLastElement) return;
+
+  const attrs: string[] = [];
+  if (data.hide) attrs.push('hide="true"');
+  if (data.title) attrs.push(`title="${data.title}"`);
+  const attrStr = attrs.length > 0 ? " " + attrs.join(" ") : "";
+  // Insert a blank line before non-default footnoteblocks
+  if (data.hide || data.title) {
+    ctx.flushPendingBlankLine();
+  }
+  ctx.pushBlockLine(`[[footnoteblock${attrStr}]]`);
+  ctx.requestBlankLine();
+}

--- a/packages/decompiler/src/serializer/heading.ts
+++ b/packages/decompiler/src/serializer/heading.ts
@@ -1,0 +1,22 @@
+import type { Element } from "@wdprlib/ast";
+import type { SerializeContext } from "./context";
+import { serializeElements } from "./serialize-element";
+
+/**
+ * Serialize a heading element using `+` prefix syntax.
+ *
+ * The number of `+` characters equals the heading level. A `*` suffix
+ * suppresses TOC inclusion (when `hasToc` is `false`).
+ */
+export function serializeHeading(
+  ctx: SerializeContext,
+  level: number,
+  hasToc: boolean,
+  elements: Element[],
+): void {
+  const prefix = "+".repeat(level);
+  const tocMarker = hasToc ? "" : "*";
+  ctx.push(prefix + tocMarker + " ");
+  serializeElements(ctx, elements);
+  ctx.push(ctx.newline);
+}

--- a/packages/decompiler/src/serializer/image.ts
+++ b/packages/decompiler/src/serializer/image.ts
@@ -1,0 +1,71 @@
+import type { ImageData, ImageSource } from "@wdprlib/ast";
+import type { SerializeContext } from "./context";
+
+/**
+ * Serialize an image element to Wikidot `[[image ...]]` syntax.
+ *
+ * Includes alignment prefix (`<`, `>`, `=`, `f<`, `f>`, `f=`), link, and
+ * additional attributes (alt, width, height, etc.).
+ */
+export function serializeImage(ctx: SerializeContext, data: ImageData): void {
+  const source = formatImageSource(data.source);
+  const attrs: string[] = [];
+
+  // Alignment → Wikidot prefix (<, >, =, f<, f>, f=)
+  let alignPrefix = "";
+  if (data.alignment) {
+    const { align, float: isFloat } = data.alignment;
+    if (isFloat) {
+      switch (align) {
+        case "left":
+          alignPrefix = "f<";
+          break;
+        case "right":
+          alignPrefix = "f>";
+          break;
+        case "center":
+          alignPrefix = "f=";
+          break;
+      }
+    } else {
+      switch (align) {
+        case "left":
+          alignPrefix = "<";
+          break;
+        case "right":
+          alignPrefix = ">";
+          break;
+        case "center":
+          alignPrefix = "=";
+          break;
+      }
+    }
+  }
+
+  if (data.link) {
+    const link = typeof data.link === "string" ? data.link : data.link.page;
+    attrs.push(`link="${link}"`);
+  }
+
+  for (const [key, value] of Object.entries(data.attributes)) {
+    if (key === "class" && value === "image") continue;
+    attrs.push(`${key}="${value}"`);
+  }
+
+  const attrStr = attrs.length > 0 ? " " + attrs.join(" ") : "";
+  ctx.push(`[[${alignPrefix}image ${source}${attrStr}]]`);
+}
+
+/** Format an {@link ImageSource} as a Wikidot source string. */
+function formatImageSource(source: ImageSource): string {
+  switch (source.type) {
+    case "url":
+      return source.data;
+    case "file1":
+      return source.data.file;
+    case "file2":
+      return `${source.data.page}/${source.data.file}`;
+    case "file3":
+      return `${source.data.site}:${source.data.page}/${source.data.file}`;
+  }
+}

--- a/packages/decompiler/src/serializer/index.ts
+++ b/packages/decompiler/src/serializer/index.ts
@@ -1,0 +1,28 @@
+import type { SyntaxTree } from "@wdprlib/ast";
+import type { SerializeOptions } from "../types";
+import { SerializeContext } from "./context";
+import { serializeElements, setCurrentTree } from "./serialize-element";
+
+/**
+ * Serialize a Wikidot AST ({@link SyntaxTree}) into Wikidot markup text.
+ *
+ * Trailing blank lines are collapsed, and the output always ends with
+ * a single newline.
+ *
+ * @param tree - The syntax tree to serialize
+ * @param options - Serialization options (e.g. newline style)
+ * @returns Wikidot markup string
+ */
+export function serialize(tree: SyntaxTree, options?: SerializeOptions): string {
+  const ctx = new SerializeContext(options);
+  setCurrentTree(tree);
+  serializeElements(ctx, tree.elements);
+
+  let output = ctx.getOutput();
+  // Collapse runs of 3+ newlines down to 2 (one blank line)
+  const nl = ctx.newline;
+  const nlEsc = nl.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+  output = output.replace(new RegExp(`(${nlEsc}){3,}`, "g"), nl + nl);
+  output = output.replace(new RegExp(`(${nlEsc})+$`), nl);
+  return output;
+}

--- a/packages/decompiler/src/serializer/link.ts
+++ b/packages/decompiler/src/serializer/link.ts
@@ -1,0 +1,76 @@
+import type { LinkData, LinkLabel } from "@wdprlib/ast";
+import type { SerializeContext } from "./context";
+
+/**
+ * Serialize a link element to Wikidot syntax.
+ *
+ * Produces the appropriate syntax for anchor (`[# label]`), page
+ * (`[[[page|label]]]`), and direct (`[url label]`) link types.
+ */
+export function serializeLink(ctx: SerializeContext, data: LinkData): void {
+  const { type, link: location, label, target, extra } = data;
+
+  switch (type) {
+    case "anchor": {
+      const labelText = extractLabelText(label);
+      ctx.push(`[# ${labelText}]`);
+      break;
+    }
+    case "page": {
+      const pageName =
+        typeof location === "string"
+          ? location
+          : location.site
+            ? `${location.site}:${location.page}`
+            : location.page;
+
+      const targetSuffix = target === "new-tab" ? "*" : "";
+      const extraSuffix = extra ?? "";
+      const labelText = extractLabelText(label);
+
+      if (label === "page" || labelText === pageName) {
+        ctx.push(`[[[${pageName}${extraSuffix}${targetSuffix}]]]`);
+      } else {
+        ctx.push(`[[[${pageName}${extraSuffix}${targetSuffix} | ${labelText}]]]`);
+      }
+      break;
+    }
+    case "direct": {
+      const url = typeof location === "string" ? location : "";
+      const labelText = extractLabelText(label);
+      const targetPrefix = target === "new-tab" ? "*" : "";
+
+      if (labelIsUrl(label, url)) {
+        ctx.push(`[${targetPrefix}${url}]`);
+      } else {
+        ctx.push(`[${targetPrefix}${url} ${labelText}]`);
+      }
+      break;
+    }
+    default: {
+      const labelText = extractLabelText(label);
+      ctx.push(labelText || (typeof location === "string" ? location : ""));
+    }
+  }
+}
+
+/** Serialize an anchor-name element as `[[# name]]`. */
+export function serializeAnchorName(ctx: SerializeContext, name: string): void {
+  ctx.push(`[[# ${name}]]`);
+}
+
+/** Extract a plain-text string from a {@link LinkLabel}. */
+function extractLabelText(label: LinkLabel): string {
+  if (label === "page") return "";
+  if ("text" in label) return label.text;
+  if ("url" in label) return label.url ?? "";
+  return "";
+}
+
+/** Check whether the label represents the URL itself (no custom label text). */
+function labelIsUrl(label: LinkLabel, url: string): boolean {
+  if (label === "page") return false;
+  if ("url" in label) return true;
+  if ("text" in label) return label.text === url;
+  return false;
+}

--- a/packages/decompiler/src/serializer/list.ts
+++ b/packages/decompiler/src/serializer/list.ts
@@ -1,0 +1,56 @@
+import type { ListData, DefinitionListItem } from "@wdprlib/ast";
+import type { SerializeContext } from "./context";
+import { serializeElements } from "./serialize-element";
+
+/**
+ * Serialize a list element to Wikidot bullet (`*`) or numbered (`#`) syntax.
+ *
+ * Nesting is represented by space indentation. The `forceLineBreakSyntax`
+ * flag is enabled during list serialization to ensure line breaks use
+ * the explicit ` _\n` form.
+ *
+ * @param ctx - Serialization context
+ * @param data - List data
+ * @param depth - Current nesting depth (0 = top-level)
+ */
+export function serializeList(ctx: SerializeContext, data: ListData, depth: number = 0): void {
+  const marker = data.type === "numbered" ? "#" : "*";
+  const prefix = " ".repeat(depth) + marker;
+
+  const prevForce = ctx.forceLineBreakSyntax;
+  ctx.forceLineBreakSyntax = true;
+  for (const item of data.items) {
+    if (item["item-type"] === "sub-list") {
+      serializeList(ctx, item.data, depth + 1);
+    } else {
+      ctx.push(`${prefix} `);
+      serializeElements(ctx, item.elements);
+      ctx.push(ctx.newline);
+    }
+  }
+  ctx.forceLineBreakSyntax = prevForce;
+
+  // Request a blank line only after the top-level list
+  if (depth === 0) {
+    ctx.requestBlankLine();
+  }
+}
+
+/**
+ * Serialize a definition list to Wikidot `: key : value` syntax.
+ *
+ * The `forceLineBreakSyntax` flag is enabled during serialization.
+ */
+export function serializeDefinitionList(ctx: SerializeContext, items: DefinitionListItem[]): void {
+  const prevForce = ctx.forceLineBreakSyntax;
+  ctx.forceLineBreakSyntax = true;
+  for (const item of items) {
+    ctx.push(": ");
+    serializeElements(ctx, item.key);
+    ctx.push(" : ");
+    serializeElements(ctx, item.value);
+    ctx.push(ctx.newline);
+  }
+  ctx.forceLineBreakSyntax = prevForce;
+  ctx.requestBlankLine();
+}

--- a/packages/decompiler/src/serializer/math.ts
+++ b/packages/decompiler/src/serializer/math.ts
@@ -1,0 +1,35 @@
+import type { MathData, MathInlineData } from "@wdprlib/ast";
+import type { SerializeContext } from "./context";
+
+/**
+ * Serialize a block math element.
+ *
+ * Single-line LaTeX is emitted inline as `[[math]] expr [[/math]]`.
+ * Multi-line LaTeX uses the block form with content on separate lines.
+ */
+export function serializeMath(ctx: SerializeContext, data: MathData): void {
+  const attrs: string[] = [];
+  if (data.name) {
+    attrs.push(data.name);
+  }
+  const attrStr = attrs.length > 0 ? " " + attrs.join(" ") : "";
+
+  if (!data["latex-source"].includes("\n")) {
+    // Single-line LaTeX → inline form
+    ctx.pushBlockLine(`[[math${attrStr}]] ${data["latex-source"]} [[/math]]`);
+  } else {
+    // Multi-line LaTeX → block form
+    ctx.pushBlockLine(`[[math${attrStr}]]`);
+    ctx.push(data["latex-source"]);
+    if (!data["latex-source"].endsWith("\n")) {
+      ctx.push(ctx.newline);
+    }
+    ctx.pushBlockLine("[[/math]]");
+  }
+  ctx.requestBlankLine();
+}
+
+/** Serialize an inline math element as `[[$ expr $]]`. */
+export function serializeMathInline(ctx: SerializeContext, data: MathInlineData): void {
+  ctx.push(`[[$ ${data["latex-source"]} $]]`);
+}

--- a/packages/decompiler/src/serializer/misc.ts
+++ b/packages/decompiler/src/serializer/misc.ts
@@ -1,0 +1,138 @@
+import type {
+  ColorData,
+  ClearFloat,
+  Embed,
+  IframeData,
+  AnchorData,
+  EmbedBlockData,
+  BibliographyCiteData,
+  BibliographyBlockData,
+} from "@wdprlib/ast";
+import type { SerializeContext } from "./context";
+import { serializeElements } from "./serialize-element";
+
+/** Serialize a color element to `##color|text##` syntax. */
+export function serializeColor(ctx: SerializeContext, data: ColorData): void {
+  // Syntax: ##color|text## — color is the raw value (e.g. "c00", "#fff", "blue", "rgb(1,2,3)")
+  ctx.push(`##${data.color}|`);
+  serializeElements(ctx, data.elements);
+  ctx.push("##");
+}
+
+/** Serialize a clear-float element to `~~~~`, `~~~~<`, or `~~~~>` syntax. */
+export function serializeClearFloat(ctx: SerializeContext, data: ClearFloat): void {
+  switch (data) {
+    case "left":
+      ctx.pushBlockLine("~~~~<");
+      break;
+    case "right":
+      ctx.pushBlockLine("~~~~>");
+      break;
+    case "both":
+      // ~~~~ (four tildes) is the canonical form for clear float both
+      ctx.pushBlockLine("~~~~");
+      break;
+  }
+  ctx.requestBlankLine();
+}
+
+/** Serialize an embed element to `[[embedvideo ...]]` syntax. */
+export function serializeEmbed(ctx: SerializeContext, data: Embed): void {
+  switch (data.embed) {
+    case "youtube":
+      ctx.pushBlockLine(`[[embedvideo youtube ${data.data["video-id"]}]]`);
+      break;
+    case "vimeo":
+      ctx.pushBlockLine(`[[embedvideo vimeo ${data.data["video-id"]}]]`);
+      break;
+    case "github-gist":
+      ctx.pushBlockLine(`[[embedvideo github-gist ${data.data.username} ${data.data.hash}]]`);
+      break;
+    case "gitlab-snippet":
+      ctx.pushBlockLine(`[[embedvideo gitlab-snippet ${data.data["snippet-id"]}]]`);
+      break;
+  }
+  ctx.requestBlankLine();
+}
+
+/** Serialize an embed-block element to `[[embed]]...[[/embed]]` syntax. */
+export function serializeEmbedBlock(ctx: SerializeContext, data: EmbedBlockData): void {
+  ctx.pushBlockLine("[[embed]]");
+  ctx.push(data.contents);
+  if (!data.contents.endsWith("\n")) {
+    ctx.push(ctx.newline);
+  }
+  ctx.pushBlockLine("[[/embed]]");
+  ctx.requestBlankLine();
+}
+
+/** Serialize an iframe element to `[[iframe url attrs]]` syntax. */
+export function serializeIframe(ctx: SerializeContext, data: IframeData): void {
+  const attrs: string[] = [];
+  for (const [key, value] of Object.entries(data.attributes)) {
+    attrs.push(`${key}="${value}"`);
+  }
+  const attrStr = attrs.length > 0 ? " " + attrs.join(" ") : "";
+  ctx.pushBlockLine(`[[iframe ${data.url}${attrStr}]]`);
+  ctx.requestBlankLine();
+}
+
+/** Serialize a style element to `[[module CSS]]...[[/module]]` syntax. */
+export function serializeStyle(ctx: SerializeContext, data: string): void {
+  ctx.pushBlockLine("[[module CSS]]");
+  ctx.push(data);
+  if (!data.endsWith("\n")) {
+    ctx.push(ctx.newline);
+  }
+  ctx.pushBlockLine("[[/module]]");
+  ctx.requestBlankLine();
+}
+
+/**
+ * Serialize an anchor element to `[[a attrs]]content[[/a]]` syntax.
+ *
+ * The `u-` prefix on id attributes is stripped (Wikidot adds it during rendering).
+ */
+export function serializeAnchor(ctx: SerializeContext, data: AnchorData): void {
+  const attrs: string[] = [];
+  for (const [key, value] of Object.entries(data.attributes)) {
+    // Strip the u- prefix from id attributes
+    if (key === "id" && value.startsWith("u-")) {
+      attrs.push(`${key}="${value.slice(2)}"`);
+    } else {
+      attrs.push(`${key}="${value}"`);
+    }
+  }
+  const attrStr = attrs.length > 0 ? " " + attrs.join(" ") : "";
+  ctx.push(`[[a${attrStr}]]`);
+  serializeElements(ctx, data.elements);
+  ctx.push("[[/a]]");
+}
+
+/** Serialize a bibliography cite element to `((bibcite label))` syntax. */
+export function serializeBibliographyCite(ctx: SerializeContext, data: BibliographyCiteData): void {
+  ctx.push(`((bibcite ${data.label}))`);
+}
+
+/** Serialize a bibliography block to `[[bibliography]]...[[/bibliography]]` syntax. */
+export function serializeBibliographyBlock(
+  ctx: SerializeContext,
+  data: BibliographyBlockData,
+): void {
+  ctx.flushPendingBlankLine();
+  ctx.pushBlockLine("[[bibliography]]");
+  for (const entry of data.entries) {
+    ctx.push(": ");
+    serializeElements(ctx, entry.key);
+    ctx.push(" : ");
+    serializeElements(ctx, entry.value);
+    ctx.push(ctx.newline);
+  }
+  ctx.pushBlockLine("[[/bibliography]]");
+  ctx.requestBlankLine();
+}
+
+/** Serialize an equation reference to `[[eref name]]` syntax. */
+export function serializeEquationRef(ctx: SerializeContext, name: string): void {
+  ctx.push(`[[eref ${name}]]`);
+}

--- a/packages/decompiler/src/serializer/serialize-element.ts
+++ b/packages/decompiler/src/serializer/serialize-element.ts
@@ -1,0 +1,171 @@
+import type { Element, SyntaxTree } from "@wdprlib/ast";
+import type { SerializeContext } from "./context";
+import {
+  serializeText,
+  serializeRaw,
+  serializeLineBreak,
+  serializeHorizontalRule,
+  serializeContentSeparator,
+  serializeEmail,
+} from "./text";
+import { serializeContainer } from "./container";
+import { serializeLink, serializeAnchorName } from "./link";
+import { serializeImage } from "./image";
+import { serializeList, serializeDefinitionList } from "./list";
+import { serializeTable } from "./table";
+import { serializeCode } from "./code";
+import { serializeCollapsible } from "./collapsible";
+import { serializeTabView } from "./tab-view";
+import { serializeFootnoteInline, serializeFootnoteRef, serializeFootnoteBlock } from "./footnote";
+import { serializeMath, serializeMathInline } from "./math";
+import {
+  serializeColor,
+  serializeClearFloat,
+  serializeEmbed,
+  serializeEmbedBlock,
+  serializeIframe,
+  serializeStyle,
+  serializeAnchor,
+  serializeBibliographyCite,
+  serializeBibliographyBlock,
+  serializeEquationRef,
+} from "./misc";
+
+let currentTree: SyntaxTree | undefined;
+let footnoteCounter = 0;
+
+/**
+ * Set the current syntax tree for footnote content lookup.
+ *
+ * Must be called before {@link serializeElements} so that footnote elements
+ * can retrieve their content from `tree.footnotes`.
+ */
+export function setCurrentTree(tree: SyntaxTree): void {
+  currentTree = tree;
+  footnoteCounter = 0;
+}
+
+/**
+ * Serialize a single AST element to Wikidot markup.
+ *
+ * Dispatches to the appropriate serializer based on `element.element`.
+ */
+export function serializeElement(ctx: SerializeContext, element: Element): void {
+  switch (element.element) {
+    case "text":
+      serializeText(ctx, element.data);
+      break;
+    case "raw":
+      serializeRaw(ctx, element.data);
+      break;
+    case "email":
+      serializeEmail(ctx, element.data);
+      break;
+    case "container":
+      serializeContainer(ctx, element.data);
+      break;
+    case "line-break":
+      serializeLineBreak(ctx);
+      break;
+    case "horizontal-rule":
+      serializeHorizontalRule(ctx);
+      break;
+    case "content-separator":
+      serializeContentSeparator(ctx);
+      break;
+    case "link":
+      serializeLink(ctx, element.data);
+      break;
+    case "anchor":
+      serializeAnchor(ctx, element.data);
+      break;
+    case "anchor-name":
+      serializeAnchorName(ctx, element.data);
+      break;
+    case "image":
+      serializeImage(ctx, element.data);
+      break;
+    case "list":
+      serializeList(ctx, element.data);
+      break;
+    case "definition-list":
+      serializeDefinitionList(ctx, element.data);
+      break;
+    case "table":
+      serializeTable(ctx, element.data);
+      break;
+    case "code":
+      serializeCode(ctx, element.data);
+      break;
+    case "collapsible":
+      serializeCollapsible(ctx, element.data);
+      break;
+    case "tab-view":
+      serializeTabView(ctx, element.data);
+      break;
+    case "footnote":
+      serializeFootnoteInline(ctx, footnoteCounter, currentTree?.footnotes);
+      footnoteCounter++;
+      break;
+    case "footnote-ref":
+      serializeFootnoteRef(ctx, element.data, currentTree?.footnotes);
+      break;
+    case "footnote-block": {
+      const isLast = (element as Record<string, unknown>)._isLastElement as boolean | undefined;
+      serializeFootnoteBlock(ctx, element.data, isLast);
+      break;
+    }
+    case "math":
+      serializeMath(ctx, element.data);
+      break;
+    case "math-inline":
+      serializeMathInline(ctx, element.data);
+      break;
+    case "equation-reference":
+      serializeEquationRef(ctx, element.data);
+      break;
+    case "color":
+      serializeColor(ctx, element.data);
+      break;
+    case "clear-float":
+      serializeClearFloat(ctx, element.data);
+      break;
+    case "embed":
+      serializeEmbed(ctx, element.data);
+      break;
+    case "embed-block":
+      serializeEmbedBlock(ctx, element.data);
+      break;
+    case "iframe":
+      serializeIframe(ctx, element.data);
+      break;
+    case "style":
+      serializeStyle(ctx, element.data);
+      break;
+    case "bibliography-cite":
+      serializeBibliographyCite(ctx, element.data);
+      break;
+    case "bibliography-block":
+      serializeBibliographyBlock(ctx, element.data);
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ * Serialize an array of AST elements in order.
+ *
+ * The last footnote-block element is annotated with `_isLastElement` so the
+ * serializer can suppress the implicit default footnote block.
+ */
+export function serializeElements(ctx: SerializeContext, elements: Element[]): void {
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i]!;
+    // Tag the last footnote-block so it can be omitted if implicit
+    if (el.element === "footnote-block" && i === elements.length - 1) {
+      (el as Record<string, unknown>)._isLastElement = true;
+    }
+    serializeElement(ctx, el);
+  }
+}

--- a/packages/decompiler/src/serializer/tab-view.ts
+++ b/packages/decompiler/src/serializer/tab-view.ts
@@ -1,0 +1,17 @@
+import type { TabData } from "@wdprlib/ast";
+import { SerializeContext } from "./context";
+import { serializeElements } from "./serialize-element";
+
+/** Serialize a tab-view element to `[[tabview]]...[[/tabview]]` syntax. */
+export function serializeTabView(ctx: SerializeContext, tabs: TabData[]): void {
+  ctx.pushBlockLine("[[tabview]]");
+  for (const tab of tabs) {
+    ctx.pushBlockLine(`[[tab ${tab.label}]]`);
+    const innerCtx = new SerializeContext({ newline: ctx.newline });
+    serializeElements(innerCtx, tab.elements);
+    ctx.push(innerCtx.getBlockInnerOutput());
+    ctx.pushBlockLine("[[/tab]]");
+  }
+  ctx.pushBlockLine("[[/tabview]]");
+  ctx.requestBlankLine();
+}

--- a/packages/decompiler/src/serializer/table.ts
+++ b/packages/decompiler/src/serializer/table.ts
@@ -1,0 +1,41 @@
+import type { TableData } from "@wdprlib/ast";
+import { SerializeContext } from "./context";
+import { serializeElements } from "./serialize-element";
+
+/**
+ * Serialize a table element to Wikidot pipe (`||`) syntax.
+ *
+ * Each cell is delimited by `||`. Header cells use `~`, alignment uses
+ * `=` (center), `>` (right), or `<` (left). Colspan is represented by
+ * additional `||` pairs before the cell marker.
+ */
+export function serializeTable(ctx: SerializeContext, data: TableData): void {
+  for (const row of data.rows) {
+    for (const cell of row.cells) {
+      // colspan: extra || pairs before the alignment/header marker
+      let prefix = "||";
+      for (let i = 1; i < cell["column-span"]; i++) {
+        prefix += "||";
+      }
+
+      if (cell.header) {
+        prefix += "~";
+      } else if (cell.align === "center") {
+        prefix += "=";
+      } else if (cell.align === "right") {
+        prefix += ">";
+      } else if (cell.align === "left") {
+        prefix += "<";
+      }
+
+      // Serialize cell content
+      const innerCtx = new SerializeContext({ newline: ctx.newline });
+      serializeElements(innerCtx, cell.elements);
+      const content = innerCtx.getOutput().replace(/\n$/, "");
+
+      ctx.push(`${prefix} ${content} `);
+    }
+    ctx.pushLine("||");
+  }
+  ctx.requestBlankLine();
+}

--- a/packages/decompiler/src/serializer/text.ts
+++ b/packages/decompiler/src/serializer/text.ts
@@ -1,0 +1,58 @@
+import type { SerializeContext } from "./context";
+
+/** Map of Unicode characters to their original Wikidot source syntax. */
+const UNICODE_TO_SOURCE: [string, string][] = [
+  ["\u00AB", "<<"], // « → <<
+  ["\u00BB", ">>"], // » → >>
+  ["\u2014", "--"], // — → --
+];
+
+/**
+ * Serialize a text element.
+ *
+ * Certain Unicode characters that Wikidot generates from source syntax
+ * (e.g. `«` from `<<`) are converted back to their source form.
+ */
+export function serializeText(ctx: SerializeContext, data: string): void {
+  let text = data;
+  for (const [unicode, source] of UNICODE_TO_SOURCE) {
+    text = text.replaceAll(unicode, source);
+  }
+  ctx.push(text);
+}
+
+/** Serialize a raw (pre-formatted) element as `@@text@@`. */
+export function serializeRaw(ctx: SerializeContext, data: string): void {
+  ctx.push(`@@${data}@@`);
+}
+
+/**
+ * Serialize a line-break element.
+ *
+ * At line start or inside lists/definition-lists, uses the explicit
+ * ` _\n` syntax. Otherwise, emits a bare newline (which Wikidot
+ * renders as `<br>` inside paragraphs).
+ */
+export function serializeLineBreak(ctx: SerializeContext): void {
+  if (ctx.isAtLineStart() || ctx.forceLineBreakSyntax) {
+    ctx.push(" _" + ctx.newline);
+  } else {
+    ctx.push(ctx.newline);
+  }
+}
+
+/** Serialize a horizontal rule as `----`. */
+export function serializeHorizontalRule(ctx: SerializeContext): void {
+  ctx.pushBlockLine("----");
+  ctx.requestBlankLine();
+}
+
+/** Serialize a content separator as `====`. */
+export function serializeContentSeparator(ctx: SerializeContext): void {
+  ctx.pushBlockLine("====");
+}
+
+/** Serialize an email address as plain text (Wikidot auto-detects emails). */
+export function serializeEmail(ctx: SerializeContext, data: string): void {
+  ctx.push(data);
+}

--- a/packages/decompiler/src/types.ts
+++ b/packages/decompiler/src/types.ts
@@ -1,0 +1,11 @@
+/** Options for {@link decompile} and {@link htmlToAst}. */
+export interface DecompileOptions {
+  /** Whether to restore footnotes inline (default: `true`). */
+  inlineFootnotes?: boolean;
+}
+
+/** Options for {@link serialize}. */
+export interface SerializeOptions {
+  /** Newline character(s) to use (default: `"\n"`). */
+  newline?: string;
+}

--- a/packages/decompiler/tsconfig.json
+++ b/packages/decompiler/tsconfig.json
@@ -17,14 +17,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "verbatimModuleSyntax": true,
-    "noEmit": true,
-    "baseUrl": ".",
-    "paths": {
-      "@wdprlib/ast": ["packages/ast/src/index.ts"],
-      "@wdprlib/decompiler": ["packages/decompiler/src/index.ts"],
-      "@wdprlib/runtime": ["packages/runtime/src/index.ts"]
-    }
+    "noEmit": true
   },
-  "include": ["packages/*/src/**/*"],
-  "exclude": ["node_modules", "**/dist", "packages/runtime"]
+  "include": ["src/**/*"]
 }

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -1,6 +1,6 @@
 # @wdprlib/parser
 
-Wikidot markup parser.
+Parser for Wikidot markup.
 
 ## Installation
 
@@ -56,6 +56,7 @@ const resolved = await resolveModules(ast, {
 
 - [@wdprlib/ast](https://www.npmjs.com/package/@wdprlib/ast) - AST type definitions
 - [@wdprlib/render](https://www.npmjs.com/package/@wdprlib/render) - HTML renderer
+- [@wdprlib/decompiler](https://www.npmjs.com/package/@wdprlib/decompiler) - HTML to Wikidot decompiler
 - [@wdprlib/runtime](https://www.npmjs.com/package/@wdprlib/runtime) - Client-side runtime
 
 ## License

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -51,6 +51,7 @@ const html = renderToHtml(ast, {
 
 - [@wdprlib/ast](https://www.npmjs.com/package/@wdprlib/ast) - AST type definitions
 - [@wdprlib/parser](https://www.npmjs.com/package/@wdprlib/parser) - Wikidot markup parser
+- [@wdprlib/decompiler](https://www.npmjs.com/package/@wdprlib/decompiler) - HTML to Wikidot decompiler
 - [@wdprlib/runtime](https://www.npmjs.com/package/@wdprlib/runtime) - Client-side runtime
 
 ## License

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,6 +1,6 @@
 # @wdprlib/runtime
 
-Client-side runtime for interactive Wikidot elements.
+Client-side runtime for Wikidot markup.
 
 ## Installation
 
@@ -48,6 +48,7 @@ runtime.destroy();
 - [@wdprlib/ast](https://www.npmjs.com/package/@wdprlib/ast) - AST type definitions
 - [@wdprlib/parser](https://www.npmjs.com/package/@wdprlib/parser) - Wikidot markup parser
 - [@wdprlib/render](https://www.npmjs.com/package/@wdprlib/render) - HTML renderer
+- [@wdprlib/decompiler](https://www.npmjs.com/package/@wdprlib/decompiler) - HTML to Wikidot decompiler
 
 ## License
 

--- a/tests/integration/fixture-roundtrip.test.ts
+++ b/tests/integration/fixture-roundtrip.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "bun:test";
+import type { SyntaxTree } from "@wdprlib/ast";
+import { serialize } from "@wdprlib/decompiler";
+import { parse } from "@wdprlib/parser";
+import { renderToHtml } from "@wdprlib/render";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Roundtrip テスト: AST → serialize → parse → render の構造等価性検証
+ *
+ * serialize結果が元のinput.ftmlと完全一致しなくても、
+ * 再パース→再レンダリングで同じHTMLが生成されれば合格とする。
+ * lossy変換（空行数、ダッシュ数、_サフィックス等）を許容する。
+ */
+
+const FIXTURES_DIR = path.join(import.meta.dir, "../fixtures");
+
+/** decompiler対象外のfixture */
+const EXCLUDED_FIXTURES = new Set<string>([
+  "module/listpages",
+  "module/listpages-misc",
+  "module/listusers/basic",
+  "module/listusers/fail",
+  "module/pagetree",
+  "module/categories",
+  "module/fail",
+  "module/rate",
+  "module/join",
+  "module/css",
+  "module/backlinks/basic",
+  "module/backlinks/fail",
+  "include/basic",
+  "include/args",
+  "include/nested",
+  "include/wikidot",
+  "iftags/basic",
+  "iftags/fail",
+  "user/basic",
+  "user/fail",
+  "html/basic",
+  "html/fail",
+  "expr/basic",
+  "expr/edge-cases",
+  "expr/if",
+  "expr/functions",
+  "expr/ifexpr",
+  "toc/basic",
+  "toc/fail",
+  "misc/comment",
+]);
+
+/**
+ * roundtripテストで追加除外するfixture
+ * serialize自体が意味のある出力を生成できないケース
+ */
+const SKIP_ROUNDTRIP = new Set<string>([
+  ...EXCLUDED_FIXTURES,
+  // エラーケース: パーサーのエラーリカバリが生成する特殊なAST構造
+  "div/fail",
+  "link/fail",
+  "collapsible/fail",
+  "list/block-fail",
+  "list/native-fail",
+  // lossy変換: ブロック構文の属性（class, id, style, rowspan等）がパイプ/ネイティブ構文で失われる
+  "table/advanced",
+  "table/nest",
+  "list/block",
+  // lossy変換: 複数@やアングルブラケットrawの複雑なエスケープ
+  "raw/basic",
+]);
+
+interface TestCase {
+  category: string;
+  expectedPath: string;
+}
+
+function discoverTestCases(): TestCase[] {
+  const cases: TestCase[] = [];
+
+  function walk(dir: string, prefix: string): void {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        walk(path.join(dir, entry.name), prefix ? `${prefix}/${entry.name}` : entry.name);
+      }
+    }
+
+    const hasExpected = entries.some((e) => e.name === "expected.json");
+    if (!hasExpected) return;
+
+    cases.push({
+      category: prefix,
+      expectedPath: path.join(dir, "expected.json"),
+    });
+  }
+
+  walk(FIXTURES_DIR, "");
+  return cases;
+}
+
+/**
+ * HTML正規化（fixture-render.test.tsと同じロジック）
+ */
+function normalizeHtml(html: string): string {
+  return (
+    html
+      .replace(/\r\n/g, "\n")
+      .replace(/ onclick="[^"]*"/g, "")
+      .replace(/\n\s*</g, "<")
+      .replace(/>\s*\n/g, ">")
+      .replace(/[ \t]+/g, " ")
+      .replace(
+        /<(\w+)((?:\s+[a-zA-Z_][\w-]*(?:="[^"]*")?)+)\s*(\/?)>/g,
+        (_match, tag, attrStr, selfClose) => {
+          const attrs = (attrStr as string).trim().match(/[a-zA-Z_][\w-]*(?:="[^"]*")?/g) || [];
+          attrs.sort();
+          return `<${tag} ${attrs.join(" ")}${selfClose ? " /" : ""}>`;
+        },
+      )
+      .replace(/>\s+</g, "><")
+      .replace(/\s*<br\s*\/?>\s*/gi, "<br />")
+      // 段落・ブロック要素の閉じタグ直前の<br />は表示上無意味なため除去
+      .replace(/<br \/><\/p>/gi, "</p>")
+      .replace(/<br \/><\/div>/gi, "</div>")
+      .replace(/<br \/><\/blockquote>/gi, "</blockquote>")
+      .replace(/&#171;/g, "\u00AB")
+      .replace(/&#187;/g, "\u00BB")
+      .replace(/&#8212;/g, "\u2014")
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .trim()
+  );
+}
+
+function getFixtureFilter(): string | undefined {
+  return process.env.FIXTURE_FILTER;
+}
+
+const FIXTURE_FILTER = getFixtureFilter();
+
+function matchesFilter(category: string): boolean {
+  if (!FIXTURE_FILTER) return true;
+  return category === FIXTURE_FILTER || category.startsWith(`${FIXTURE_FILTER}/`);
+}
+
+const allCases = discoverTestCases();
+const filteredCases = allCases.filter((c) => matchesFilter(c.category));
+const roundtripCases = filteredCases.filter((c) => !SKIP_ROUNDTRIP.has(c.category));
+
+describe("Serialize Roundtrip: AST → serialize → parse → render", () => {
+  for (const testCase of roundtripCases) {
+    it(`[${testCase.category}] roundtrip should produce equivalent HTML`, () => {
+      const expectedJson = fs.readFileSync(testCase.expectedPath, "utf-8");
+      const syntaxTree: SyntaxTree = JSON.parse(expectedJson);
+
+      // 元のASTをレンダリング
+      const originalHtml = renderToHtml(syntaxTree);
+
+      // AST → serialize → parse → render
+      const source = serialize(syntaxTree);
+      const { ast: reparsedAst } = parse(source);
+      const roundtripHtml = renderToHtml(reparsedAst);
+
+      expect(normalizeHtml(roundtripHtml)).toBe(normalizeHtml(originalHtml));
+    });
+  }
+});
+
+// Summary
+const skipped = filteredCases.filter((c) => SKIP_ROUNDTRIP.has(c.category)).length;
+console.log("\n[Roundtrip Tests]");
+if (FIXTURE_FILTER) {
+  console.log(`  Filter: ${FIXTURE_FILTER}`);
+}
+console.log(`  Total: ${allCases.length}`);
+console.log(`  Roundtrip: ${roundtripCases.length} tested, ${skipped} skipped`);

--- a/tests/integration/fixture-roundtrip.test.ts
+++ b/tests/integration/fixture-roundtrip.test.ts
@@ -128,9 +128,9 @@ function normalizeHtml(html: string): string {
       .replace(/&#187;/g, "\u00BB")
       .replace(/&#8212;/g, "\u2014")
       .replace(/&quot;/g, '"')
-      .replace(/&amp;/g, "&")
       .replace(/&lt;/g, "<")
       .replace(/&gt;/g, ">")
+      .replace(/&amp;/g, "&")
       .trim()
   );
 }


### PR DESCRIPTION
## Summary

- `@wdprlib/decompiler` パッケージを新規作成
 - HTML → AST (`htmlToAst`) と AST → Wikidot構文 (`serialize`) の2段階変換
 - `decompile(html)` で一括変換
- フォーラム投稿HTMLからWikidot構文を再生成するのが主な用途
- roundtripテスト: 67フィクスチャ全パス
- `examples/decompiler-preview/` にデモアプリを追加（Vite SPA、2ペイン+タブ切替）

## Supported elements

Inline: bold, italics, underline, strikethrough, superscript, subscript, monospace, color, links, images, math, footnotes, anchors, bibliography cites

Block: paragraphs, headings, blockquotes, alignment, divs, spans, lists, definition lists, tables, code blocks, collapsible blocks, tab views, math, embeds, iframes, horizontal rules, clear floats,
footnote blocks, bibliography blocks, CSS modules

## Limitations

- Best-effort conversion（再パースで構造的に等価なHTMLが生成されればOK）
- コードブロックの言語検出（ハイライト済みHTML）は非対応
- modules, includes, iftags, commentsはスコープ外