### PR TITLE
fix: includeの行頭限定とembed iframeのstyle/class属性保持

### DIFF
--- a/packages/parser/src/parser/rules/block/module/include/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/include/resolve.ts
@@ -90,9 +90,12 @@ export function resolveIncludes(
 /**
  * Regex to match [[include ...]] directives.
  * Captures the content between [[include and ]] (may span multiple lines).
+ *
+ * The `m` flag makes `^` match at line boundaries, enforcing the Wikidot
+ * rule that `[[include]]` must appear at the start of a line.
  */
 // \s (single char, no quantifier) avoids overlap with [^\]]* that causes polynomial backtracking
-const INCLUDE_PATTERN = /\[\[include\s([^\]]*(?:\](?!\])[^\]]*)*)\]\]/gi;
+const INCLUDE_PATTERN = /^\[\[include\s([^\]]*(?:\](?!\])[^\]]*)*)\]\]/gim;
 
 /**
  * Parse the inner content of an `[[include ...]]` directive into a page reference

--- a/packages/render/src/elements/embed-block.ts
+++ b/packages/render/src/elements/embed-block.ts
@@ -96,7 +96,9 @@ const SANITIZE_CONFIG: sanitizeHtml.IOptions = {
   allowedTags: ["iframe"],
   allowedAttributes: {
     iframe: [
+      "class",
       "src",
+      "style",
       "allow",
       "allowfullscreen",
       "frameborder",

--- a/tests/unit/module/include/resolve.test.ts
+++ b/tests/unit/module/include/resolve.test.ts
@@ -210,6 +210,22 @@ describe("resolveIncludes", () => {
     expect(expanded).toBe("Before\nIncluded\nAfter");
   });
 
+  test("does not resolve include that is not at line start", () => {
+    const source = "abc [[include my-page]]";
+    const fetcher = () => "Should not appear";
+
+    const expanded = resolveIncludes(source, fetcher);
+    expect(expanded).toBe("abc [[include my-page]]");
+  });
+
+  test("does not resolve include preceded by @@", () => {
+    const source = "@@[[include my-page]]@@";
+    const fetcher = () => "Should not appear";
+
+    const expanded = resolveIncludes(source, fetcher);
+    expect(expanded).toBe("@@[[include my-page]]@@");
+  });
+
   test("div blocks spanning across includes are correctly parsed", () => {
     const source = "[[include credit:start]]\naaa\n[[include credit:end]]";
     const fetcher = (pageRef: { site: string | null; page: string }) => {

--- a/tests/unit/parser/settings.test.ts
+++ b/tests/unit/parser/settings.test.ts
@@ -129,19 +129,19 @@ describe("WikitextSettings - Parser", () => {
     const fetcher = (ref: { page: string }) => `Content of ${ref.page}`;
 
     it("skips expansion when enablePageSyntax = false", () => {
-      const source = "Before [[include test-page]] After";
+      const source = "Before\n[[include test-page]]\nAfter";
       const result = resolveIncludes(source, fetcher, { settings: forumSettings });
       expect(result).toBe(source);
     });
 
     it("expands when enablePageSyntax = true", () => {
-      const source = "Before [[include test-page]] After";
+      const source = "Before\n[[include test-page]]\nAfter";
       const result = resolveIncludes(source, fetcher, { settings: pageSettings });
       expect(result).toContain("Content of test-page");
     });
 
     it("expands when settings not specified (backward compat)", () => {
-      const source = "Before [[include test-page]] After";
+      const source = "Before\n[[include test-page]]\nAfter";
       const result = resolveIncludes(source, fetcher);
       expect(result).toContain("Content of test-page");
     });

--- a/tests/unit/render/embed-block.test.ts
+++ b/tests/unit/render/embed-block.test.ts
@@ -338,6 +338,30 @@ describe("embed-block security", () => {
     });
   });
 
+  describe("iframe attributes preservation", () => {
+    test("style attribute is preserved on iframe", () => {
+      const ctx = createMockContext({ embedAllowlist: null });
+      const data = {
+        contents: '<iframe src="https://example.com/frame.html" style="display: none"></iframe>',
+      };
+      renderEmbedBlock(ctx, data);
+      const output = ctx.getOutput();
+      expect(output).not.toContain("error-block");
+      expect(output).toMatch(/style="display:\s*none"/);
+    });
+
+    test("class attribute is preserved on iframe", () => {
+      const ctx = createMockContext({ embedAllowlist: null });
+      const data = {
+        contents: '<iframe src="https://example.com/frame.html" class="my-iframe"></iframe>',
+      };
+      renderEmbedBlock(ctx, data);
+      const output = ctx.getOutput();
+      expect(output).not.toContain("error-block");
+      expect(output).toContain('class="my-iframe"');
+    });
+  });
+
   describe("custom allowlist", () => {
     test("Custom allowlist with host only", () => {
       const allowlist: EmbedAllowlistEntry[] = [{ host: "example.com" }];


### PR DESCRIPTION
## Summary
- `[[include]]`の正規表現に`^`アンカーと`m`フラグを追加し、行頭以外のincludeを展開しないように修正
- embed-blockの`sanitize-html`設定にiframeの`style`と`class`属性を追加