### PR TITLE
fix: トリプルブラケットリンクの*prefixがpipe付きで機能しない問題を修正

### DIFF
--- a/packages/parser/src/parser/rules/inline/link-triple.ts
+++ b/packages/parser/src/parser/rules/inline/link-triple.ts
@@ -12,7 +12,8 @@
  * - Interwiki links: `[[[wikipedia:Article]]]` (for known prefixes)
  *
  * Special syntax:
- * - `[[[*page]]]` -- `*` prefix is treated as a label prefix (ignored in target)
+ * - `[[[*target]]]` -- `*` prefix is stripped from target; for external URLs,
+ *   adds `target="_blank"` (new tab)
  * - `[[[*|label]]]` -- links to root `/` with the given label
  * - `[[[page|]]]` -- empty label after pipe defaults to the page name
  *
@@ -86,7 +87,7 @@ function hasClosingLinkMarker(ctx: ParseContext, startPos: number): boolean {
  * - Empty target with pipe (`[[[|text]]]`) is invalid
  * - Multiple consecutive `#` in the target (`[[[page##anchor]]]`) is invalid
  * - `[[[*|label]]]` links to root `/`
- * - `[[[*page]]]` strips the `*` prefix from the target
+ * - `[[[*target]]]` strips `*`; adds `target="_blank"` for external URLs
  * - Category pages show only the text after the colon when no label is given
  */
 export const linkTripleRule: InlineRule = {
@@ -174,13 +175,11 @@ export const linkTripleRule: InlineRule = {
       };
     }
 
-    // Special case: [[[*|label]]] means link to root "/" with label
+    // `*` prefix: stripped from target; sets target="_blank" for external URLs
     let finalTarget = trimmedTarget;
-    if (trimmedTarget === "*" && foundPipe) {
-      finalTarget = "";
-    }
-    // Special case: [[[*page]]] - * is a label prefix, page is the target
-    if (trimmedTarget.startsWith("*") && !foundPipe) {
+    let hasStar = false;
+    if (trimmedTarget.startsWith("*")) {
+      hasStar = true;
       finalTarget = trimmedTarget.slice(1);
     }
 
@@ -194,8 +193,9 @@ export const linkTripleRule: InlineRule = {
       displayText = trimmedLabel || finalTarget;
     } else {
       // For category pages (system:Recent Changes), use only the part after colon
+      // Use trimmedTarget (preserves * prefix) for display when no pipe
       const colonIdx = trimmedTarget.indexOf(":");
-      if (colonIdx !== -1 && !trimmedTarget.startsWith("http")) {
+      if (colonIdx !== -1 && !trimmedTarget.startsWith("http") && !trimmedTarget.startsWith("*")) {
         displayText = trimmedTarget.slice(colonIdx + 1).trim();
       } else {
         displayText = trimmedTarget;
@@ -214,7 +214,7 @@ export const linkTripleRule: InlineRule = {
             link,
             extra: null,
             label,
-            target: null,
+            target: hasStar && linkType === "direct" ? "new-tab" : null,
           },
         },
       ],

--- a/tests/fixtures/link/triple/expected.json
+++ b/tests/fixtures/link/triple/expected.json
@@ -531,6 +531,84 @@
       }
     },
     {
+      "element": "container",
+      "data": {
+        "type": "paragraph",
+        "attributes": {},
+        "elements": [
+          {
+            "element": "container",
+            "data": {
+              "type": "bold",
+              "attributes": {},
+              "elements": [
+                {
+                  "element": "text",
+                  "data": "Star"
+                },
+                {
+                  "element": "text",
+                  "data": " "
+                },
+                {
+                  "element": "text",
+                  "data": "prefix"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "element": "list",
+      "data": {
+        "type": "bullet",
+        "attributes": {},
+        "items": [
+          {
+            "item-type": "elements",
+            "attributes": {},
+            "elements": [
+              {
+                "element": "link",
+                "data": {
+                  "type": "direct",
+                  "link": "http://example.com",
+                  "extra": null,
+                  "label": {
+                    "text": "example"
+                  },
+                  "target": "new-tab"
+                }
+              }
+            ]
+          },
+          {
+            "item-type": "elements",
+            "attributes": {},
+            "elements": [
+              {
+                "element": "link",
+                "data": {
+                  "type": "page",
+                  "link": {
+                    "site": null,
+                    "page": "test"
+                  },
+                  "extra": null,
+                  "label": {
+                    "text": "*test"
+                  },
+                  "target": null
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "element": "footnote-block",
       "data": {
         "title": null,

--- a/tests/fixtures/link/triple/input.ftml
+++ b/tests/fixtures/link/triple/input.ftml
@@ -23,3 +23,7 @@
 
 **URL**
 * [[[https://example.com/|Example]]]
+
+**Star prefix**
+* [[[*http://example.com|example]]]
+* [[[*test|*test]]]

--- a/tests/fixtures/link/triple/output.html
+++ b/tests/fixtures/link/triple/output.html
@@ -31,3 +31,8 @@
 <ul>
 <li><a href="https://example.com/">Example</a></li>
 </ul>
+<p><strong>Star prefix</strong></p>
+<ul>
+<li><a href="http://example.com" target="_blank" rel="noopener noreferrer">example</a></li>
+<li><a class="newpage" href="/test">*test</a></li>
+</ul>

--- a/tests/fixtures/link/triple/wikidot.html
+++ b/tests/fixtures/link/triple/wikidot.html
@@ -31,3 +31,8 @@
 <ul>
 <li><a href="https://example.com/">Example</a></li>
 </ul>
+<p><strong>Star prefix</strong></p>
+<ul>
+<li><a target="_blank" href="http://example.com">example</a></li>
+<li><a href="/test">*test</a></li>
+</ul>


### PR DESCRIPTION
## Summary
- `[[[*http://url|label]]]` で `*` prefix
が除去されず、URLがページリンクとして誤認識される問題を修正
- `*` prefix の除去を pipe の有無に関わらず実行するよう変更
- 外部URL（http/https）の場合のみ `target: "new-tab"` を設定

## 変更内容
- `packages/parser/src/parser/rules/inline/link-triple.ts`: `*` prefix の処理ロジック修正
- `tests/fixtures/link/triple/`: star prefix のテストケース追加

## Wikidot実機確認結果
| 入力 | Wikidot出力 |
|------|-----------|
| `[[[*http://url\|label]]]` | `<a target="_blank" href="http://url">label</a>` |
| `[[[*test\|*test]]]` | `<a href="/test">*test</a>` |