### PR TITLE
fix: QUOTED_STRINGがインラインのリンク構文を飲み込む問題を修正

### DIFF
--- a/packages/parser/src/lexer/lexer.ts
+++ b/packages/parser/src/lexer/lexer.ts
@@ -177,6 +177,17 @@ export class Lexer {
   }
 
   /**
+   * Returns the type of the last non-whitespace token, or null if none.
+   */
+  private lastNonWhitespaceTokenType(): TokenType | null {
+    for (let i = this.state.tokens.length - 1; i >= 0; i--) {
+      const t = this.state.tokens[i]!;
+      if (t.type !== "WHITESPACE") return t.type;
+    }
+    return null;
+  }
+
+  /**
    * Add token
    */
   private addToken(type: TokenType, value: string): void {
@@ -543,16 +554,23 @@ export class Lexer {
       return;
     }
 
-    // Quoted string
+    // Quoted string (only after EQUALS for block attribute values)
+    // In inline context, " is just a text character (typographic quotes)
     if (char === '"') {
-      let quoted = this.advance(); // opening "
-      while (!this.isAtEnd() && this.current() !== '"' && this.current() !== "\n") {
-        quoted += this.advance();
+      const lastNonWs = this.lastNonWhitespaceTokenType();
+      if (lastNonWs === "EQUALS") {
+        let quoted = this.advance(); // opening "
+        while (!this.isAtEnd() && this.current() !== '"' && this.current() !== "\n") {
+          quoted += this.advance();
+        }
+        if (this.current() === '"') {
+          quoted += this.advance(); // closing "
+        }
+        this.addToken("QUOTED_STRING", quoted);
+        return;
       }
-      if (this.current() === '"') {
-        quoted += this.advance(); // closing "
-      }
-      this.addToken("QUOTED_STRING", quoted);
+      this.advance();
+      this.addToken("TEXT", '"');
       return;
     }
 

--- a/tests/fixtures/footnote/basic/expected.json
+++ b/tests/fixtures/footnote/basic/expected.json
@@ -340,7 +340,15 @@
             },
             {
               "element": "text",
-              "data": "\"fruit\""
+              "data": "\""
+            },
+            {
+              "element": "text",
+              "data": "fruit"
+            },
+            {
+              "element": "text",
+              "data": "\""
             },
             {
               "element": "text",
@@ -360,7 +368,15 @@
             },
             {
               "element": "text",
-              "data": "\"vegetable\""
+              "data": "\""
+            },
+            {
+              "element": "text",
+              "data": "vegetable"
+            },
+            {
+              "element": "text",
+              "data": "\""
             },
             {
               "element": "text",

--- a/tests/fixtures/link/triple/expected.json
+++ b/tests/fixtures/link/triple/expected.json
@@ -133,7 +133,23 @@
               },
               {
                 "element": "text",
-                "data": "\"Recent Changes\""
+                "data": "\""
+              },
+              {
+                "element": "text",
+                "data": "Recent"
+              },
+              {
+                "element": "text",
+                "data": " "
+              },
+              {
+                "element": "text",
+                "data": "Changes"
+              },
+              {
+                "element": "text",
+                "data": "\""
               },
               {
                 "element": "text",

--- a/tests/fixtures/misc/string/expected.json
+++ b/tests/fixtures/misc/string/expected.json
@@ -16,7 +16,15 @@
           },
           {
             "element": "text",
-            "data": "\"string\""
+            "data": "\""
+          },
+          {
+            "element": "text",
+            "data": "string"
+          },
+          {
+            "element": "text",
+            "data": "\""
           },
           {
             "element": "text",
@@ -41,7 +49,75 @@
         "elements": [
           {
             "element": "text",
-            "data": "\"This one\\x01 has\\t escapes \\n\\b\""
+            "data": "\""
+          },
+          {
+            "element": "text",
+            "data": "This"
+          },
+          {
+            "element": "text",
+            "data": " "
+          },
+          {
+            "element": "text",
+            "data": "one"
+          },
+          {
+            "element": "text",
+            "data": "\\"
+          },
+          {
+            "element": "text",
+            "data": "x01"
+          },
+          {
+            "element": "text",
+            "data": " "
+          },
+          {
+            "element": "text",
+            "data": "has"
+          },
+          {
+            "element": "text",
+            "data": "\\"
+          },
+          {
+            "element": "text",
+            "data": "t"
+          },
+          {
+            "element": "text",
+            "data": " "
+          },
+          {
+            "element": "text",
+            "data": "escapes"
+          },
+          {
+            "element": "text",
+            "data": " "
+          },
+          {
+            "element": "text",
+            "data": "\\"
+          },
+          {
+            "element": "text",
+            "data": "n"
+          },
+          {
+            "element": "text",
+            "data": "\\"
+          },
+          {
+            "element": "text",
+            "data": "b"
+          },
+          {
+            "element": "text",
+            "data": "\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
- レクサーが `"..."` を無条件に `QUOTED_STRING`トークンとして一括取り込みするため、`"[[[*http://url|label]]]"`
内のリンク構文がパースされない問題を修正
- `QUOTED_STRING` トークン化を `EQUALS`直後（ブロック属性値）に限定し、インラインコンテキストでは `"` を `TEXT` トークンとして扱うよう変更