### PR TITLE
fix: [[iframe]]のclass/align属性がパースされない問題を修正

### DIFF
--- a/packages/parser/src/parser/rules/block/iframe.ts
+++ b/packages/parser/src/parser/rules/block/iframe.ts
@@ -12,9 +12,10 @@
  * - URL normalisation strips whitespace and control characters to prevent
  *   evasion via character insertion.
  * - Only a specific set of HTML attributes is allowed (Wikidot filters
- *   out `class` and `id`).
+ *   out `id` but permits `class`).
  *
- * Allowed attributes: `width`, `height`, `style`, `scrolling`, `frameborder`.
+ * Allowed attributes: `align`, `class`, `frameborder`, `height`,
+ * `scrolling`, `style`, `width`.
  *
  * @module
  */
@@ -25,9 +26,17 @@ import { parseBlockName } from "./utils";
 
 /**
  * Whitelist of attributes permitted on `[[iframe]]`. Wikidot strips
- * `class` and `id` for security reasons.
+ * `id` but permits `class`.
  */
-const ALLOWED_IFRAME_ATTRS = new Set(["width", "height", "style", "scrolling", "frameborder"]);
+const ALLOWED_IFRAME_ATTRS = new Set([
+  "align",
+  "class",
+  "frameborder",
+  "height",
+  "scrolling",
+  "style",
+  "width",
+]);
 
 /**
  * Normalises a URL string for security checks by removing whitespace and

--- a/tests/fixtures/iframe/basic/expected.json
+++ b/tests/fixtures/iframe/basic/expected.json
@@ -19,6 +19,7 @@
       "data": {
         "url": "https://example.com/",
         "attributes": {
+          "class": "iframe",
           "width": "90%"
         }
       }
@@ -28,6 +29,7 @@
       "data": {
         "url": "https://example.com/",
         "attributes": {
+          "class": "iframe",
           "style": "width: 90%"
         }
       }

--- a/tests/fixtures/iframe/basic/output.html
+++ b/tests/fixtures/iframe/basic/output.html
@@ -1,4 +1,4 @@
 <p><iframe src="https://example.com/some-page" align="" frameborder="" height="" scrolling="" width="" class="" style=""></iframe></p>
 <p><iframe src="http://example.org/http" align="" frameborder="" height="" scrolling="" width="" class="" style=""></iframe></p>
-<p><iframe src="https://example.com/" align="" frameborder="" height="" scrolling="" width="90%" class="" style=""></iframe></p>
-<p><iframe src="https://example.com/" align="" frameborder="" height="" scrolling="" width="" class="" style="width: 90%"></iframe></p>
+<p><iframe src="https://example.com/" align="" frameborder="" height="" scrolling="" width="90%" class="iframe" style=""></iframe></p>
+<p><iframe src="https://example.com/" align="" frameborder="" height="" scrolling="" width="" class="iframe" style="width: 90%"></iframe></p>


### PR DESCRIPTION
## Summary
- パーサーの`ALLOWED_IFRAME_ATTRS`に`align`と`class`が含まれていない状態
- レンダラーは`class`/`align`を出力対象にしていたが、パーサーが通さないため常に空文字になっていた