### PR TITLE
fix(ci): bunバージョンを1.3.9に固定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.9"
 
       - run: bun install --frozen-lockfile
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.9"
 
       - run: bun install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.9"
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- Bun 1.3.10の`sideEffects`バグ([oven-sh/bun#27709](https://github.com/oven-sh/bun/issues/27709))により、ESMビルドが空(re-exportのみ)になる問題を回避
- 全workflow(ci, docs, release)の`bun-version`を`latest`から`1.3.9`に固定