### PR TITLE
fix: [[collapsible]]内で段落分けされない問題を修正

### DIFF
--- a/packages/parser/src/parser/rules/block/collapsible.ts
+++ b/packages/parser/src/parser/rules/block/collapsible.ts
@@ -143,13 +143,13 @@ function consumeCloseTag(ctx: ParseContext, pos: number): number {
  *
  * When a `[[collapsible]]` token appears inside a collapsible body (the rule
  * is filtered out to prevent nesting), the paragraph parser treats the
- * `BLOCK_OPEN` as a paragraph boundary, splitting content that Wikidot keeps
- * in a single paragraph. This function detects those artificial splits —
- * paragraphs whose first text element is `"[["` — and merges them back,
- * inserting a line-break between runs.
+ * `BLOCK_OPEN` or `BLOCK_END_OPEN` as a paragraph boundary, splitting content
+ * that Wikidot keeps in a single paragraph. This function detects those
+ * artificial splits — paragraphs whose first text element is `"[["` or
+ * `"[[/"` — and merges them back, inserting a line-break between runs.
  *
  * Paragraphs separated by blank lines (double newline) do NOT start with
- * `"[["` and are therefore left as separate paragraphs.
+ * block-open text and are therefore left as separate paragraphs.
  */
 function mergeSplitParagraphs(elements: Element[]): Element[] {
   const result: Element[] = [];
@@ -168,12 +168,12 @@ function mergeSplitParagraphs(elements: Element[]): Element[] {
       continue;
     }
 
-    // Check if this paragraph starts with "[[" (unrecognised block token)
+    // Check if this paragraph starts with "[[" or "[[/" (unrecognised block token)
     const firstElem = elem.data.elements[0];
     const startsWithBlockOpen =
       firstElem?.element === "text" &&
       typeof firstElem.data === "string" &&
-      firstElem.data === "[[";
+      (firstElem.data === "[[" || firstElem.data === "[[/");
 
     if (!startsWithBlockOpen) {
       result.push(elem);

--- a/packages/parser/src/parser/rules/block/collapsible.ts
+++ b/packages/parser/src/parser/rules/block/collapsible.ts
@@ -19,9 +19,6 @@
  *   emitted as `<br />` + literal text, matching Wikidot rendering.
  * - An inline form (`[[collapsible]]text[[/collapsible]]` on one line) is
  *   supported but uncommon.
- * - Consecutive paragraph containers in the body are merged back into a single
- *   paragraph via `mergeParagraphs`, because Wikidot does not split
- *   paragraphs at unrecognised block tokens inside a collapsible.
  *
  * @module
  */
@@ -141,66 +138,64 @@ function consumeCloseTag(ctx: ParseContext, pos: number): number {
 }
 
 /**
- * Merges consecutive paragraph container elements into a single paragraph.
+ * Merges consecutive paragraph containers that were split by unrecognised
+ * block tokens back into the preceding paragraph.
  *
- * When the collapsible rule is disabled during body parsing (to prevent
- * nesting), unrecognised `[[collapsible...]]` tokens cause the paragraph
- * parser to split content into multiple paragraphs. Wikidot itself keeps
- * this content as one paragraph, so this function re-joins them, inserting
- * line-break elements between the merged runs.
+ * When a `[[collapsible]]` token appears inside a collapsible body (the rule
+ * is filtered out to prevent nesting), the paragraph parser treats the
+ * `BLOCK_OPEN` as a paragraph boundary, splitting content that Wikidot keeps
+ * in a single paragraph. This function detects those artificial splits —
+ * paragraphs whose first text element is `"[["` — and merges them back,
+ * inserting a line-break between runs.
  *
- * Non-paragraph elements (divs, tables, etc.) act as merge boundaries and
- * are emitted as-is.
- *
- * @param elements - The body elements produced by block parsing.
- * @returns A new array with adjacent paragraphs merged.
+ * Paragraphs separated by blank lines (double newline) do NOT start with
+ * `"[["` and are therefore left as separate paragraphs.
  */
-function mergeParagraphs(elements: Element[]): Element[] {
+function mergeSplitParagraphs(elements: Element[]): Element[] {
   const result: Element[] = [];
-  let mergedElements: Element[] = [];
 
   for (const elem of elements) {
     if (
-      elem.element === "container" &&
-      elem.data &&
-      typeof elem.data === "object" &&
-      "type" in elem.data &&
-      elem.data.type === "paragraph"
+      elem.element !== "container" ||
+      !elem.data ||
+      typeof elem.data !== "object" ||
+      !("type" in elem.data) ||
+      elem.data.type !== "paragraph" ||
+      !("elements" in elem.data) ||
+      !Array.isArray(elem.data.elements)
     ) {
-      // Add line-break between merged paragraphs
-      if (mergedElements.length > 0) {
-        mergedElements.push({ element: "line-break" });
-      }
-      if ("elements" in elem.data && Array.isArray(elem.data.elements)) {
-        mergedElements.push(...elem.data.elements);
-      }
+      result.push(elem);
+      continue;
+    }
+
+    // Check if this paragraph starts with "[[" (unrecognised block token)
+    const firstElem = elem.data.elements[0];
+    const startsWithBlockOpen =
+      firstElem?.element === "text" &&
+      typeof firstElem.data === "string" &&
+      firstElem.data === "[[";
+
+    if (!startsWithBlockOpen) {
+      result.push(elem);
+      continue;
+    }
+
+    // Try to merge into the previous paragraph
+    const prev = result[result.length - 1];
+    if (
+      prev?.element === "container" &&
+      prev.data &&
+      typeof prev.data === "object" &&
+      "type" in prev.data &&
+      prev.data.type === "paragraph" &&
+      "elements" in prev.data &&
+      Array.isArray(prev.data.elements)
+    ) {
+      prev.data.elements.push({ element: "line-break" });
+      prev.data.elements.push(...elem.data.elements);
     } else {
-      // Non-paragraph element: flush merged paragraphs
-      if (mergedElements.length > 0) {
-        result.push({
-          element: "container",
-          data: {
-            type: "paragraph",
-            attributes: {},
-            elements: mergedElements,
-          },
-        });
-        mergedElements = [];
-      }
       result.push(elem);
     }
-  }
-
-  // Flush remaining merged paragraphs
-  if (mergedElements.length > 0) {
-    result.push({
-      element: "container",
-      data: {
-        type: "paragraph",
-        attributes: {},
-        elements: mergedElements,
-      },
-    });
   }
 
   return result;
@@ -216,11 +211,10 @@ function mergeParagraphs(elements: Element[]): Element[] {
  *    with the collapsible rule itself removed (to prevent nesting).
  *    Otherwise, parse inline content until close tag or end of line
  *    (inline form).
- * 4. Merge consecutive paragraphs in the body via `mergeParagraphs()`.
- * 5. Consume the `[[/collapsible]]` closing tag.
- * 6. Consume any orphaned `[[/collapsible]]` tags that follow, converting
+ * 4. Consume the `[[/collapsible]]` closing tag.
+ * 5. Consume any orphaned `[[/collapsible]]` tags that follow, converting
  *    them to `<br />` + literal text.
- * 7. Derive `show-top` / `show-bottom` booleans from the `hideLocation`
+ * 6. Derive `show-top` / `show-bottom` booleans from the `hideLocation`
  *    attribute.
  */
 export const collapsibleRule: BlockRule = {
@@ -320,9 +314,9 @@ export const collapsibleRule: BlockRule = {
       consumed += bodyResult.consumed;
       pos += bodyResult.consumed;
 
-      // Merge consecutive paragraphs into one (Wikidot doesn't split paragraphs
-      // at unrecognized [[block]] tokens inside collapsible)
-      bodyElements = mergeParagraphs(bodyResult.elements);
+      // Merge paragraphs that were artificially split by unrecognised
+      // [[collapsible]] tokens (nested collapsible is treated as plain text)
+      bodyElements = mergeSplitParagraphs(bodyResult.elements);
     }
 
     // Check for missing close tag

--- a/packages/parser/src/parser/rules/block/collapsible.ts
+++ b/packages/parser/src/parser/rules/block/collapsible.ts
@@ -137,69 +137,8 @@ function consumeCloseTag(ctx: ParseContext, pos: number): number {
   return closeConsumed;
 }
 
-/**
- * Merges consecutive paragraph containers that were split by unrecognised
- * block tokens back into the preceding paragraph.
- *
- * When a `[[collapsible]]` token appears inside a collapsible body (the rule
- * is filtered out to prevent nesting), the paragraph parser treats the
- * `BLOCK_OPEN` or `BLOCK_END_OPEN` as a paragraph boundary, splitting content
- * that Wikidot keeps in a single paragraph. This function detects those
- * artificial splits — paragraphs whose first text element is `"[["` or
- * `"[[/"` — and merges them back, inserting a line-break between runs.
- *
- * Paragraphs separated by blank lines (double newline) do NOT start with
- * block-open text and are therefore left as separate paragraphs.
- */
-function mergeSplitParagraphs(elements: Element[]): Element[] {
-  const result: Element[] = [];
-
-  for (const elem of elements) {
-    if (
-      elem.element !== "container" ||
-      !elem.data ||
-      typeof elem.data !== "object" ||
-      !("type" in elem.data) ||
-      elem.data.type !== "paragraph" ||
-      !("elements" in elem.data) ||
-      !Array.isArray(elem.data.elements)
-    ) {
-      result.push(elem);
-      continue;
-    }
-
-    // Check if this paragraph starts with "[[" or "[[/" (unrecognised block token)
-    const firstElem = elem.data.elements[0];
-    const startsWithBlockOpen =
-      firstElem?.element === "text" &&
-      typeof firstElem.data === "string" &&
-      (firstElem.data === "[[" || firstElem.data === "[[/");
-
-    if (!startsWithBlockOpen) {
-      result.push(elem);
-      continue;
-    }
-
-    // Try to merge into the previous paragraph
-    const prev = result[result.length - 1];
-    if (
-      prev?.element === "container" &&
-      prev.data &&
-      typeof prev.data === "object" &&
-      "type" in prev.data &&
-      prev.data.type === "paragraph" &&
-      "elements" in prev.data &&
-      Array.isArray(prev.data.elements)
-    ) {
-      prev.data.elements.push({ element: "line-break" });
-      prev.data.elements.push(...elem.data.elements);
-    } else {
-      result.push(elem);
-    }
-  }
-
-  return result;
-}
+/** Block names excluded from rule dispatch and paragraph-boundary detection. */
+const EXCLUDED_BLOCKS = new Set(["collapsible"]);
 
 /**
  * Block rule for `[[collapsible ...]]...[[/collapsible]]`.
@@ -208,7 +147,7 @@ function mergeSplitParagraphs(elements: Element[]): Element[] {
  * 1. Match BLOCK_OPEN + name "collapsible".
  * 2. Parse multiline attributes (show, hide, folded, hideLocation, etc.).
  * 3. If a NEWLINE follows the opening tag, parse body as block content
- *    with the collapsible rule itself removed (to prevent nesting).
+ *    with the collapsible rule itself excluded (to prevent nesting).
  *    Otherwise, parse inline content until close tag or end of line
  *    (inline form).
  * 4. Consume the `[[/collapsible]]` closing tag.
@@ -299,24 +238,22 @@ export const collapsibleRule: BlockRule = {
       }
     } else {
       // Block form: parse content recursively until [[/collapsible]]
-      // Collapsible cannot be nested in Wikidot - nested [[collapsible]] becomes plain text
-      const bodyCtx: ParseContext = {
-        ...ctx,
-        pos,
-        blockRules: ctx.blockRules.filter((r) => r.name !== "collapsible"),
-      };
+      // Collapsible cannot be nested in Wikidot - nested [[collapsible]] becomes plain text.
+      // excludedBlockNames removes the collapsible rule from dispatch AND prevents
+      // [[collapsible]] / [[/collapsible]] tokens from triggering paragraph splits.
+      const bodyCtx: ParseContext = { ...ctx, pos };
 
       const closeCondition = (checkCtx: ParseContext): boolean => {
         return isCollapsibleClose(checkCtx, checkCtx.pos);
       };
 
-      const bodyResult = parseBlocksUntil(bodyCtx, closeCondition);
+      const bodyResult = parseBlocksUntil(bodyCtx, closeCondition, {
+        excludedBlockNames: EXCLUDED_BLOCKS,
+      });
       consumed += bodyResult.consumed;
       pos += bodyResult.consumed;
 
-      // Merge paragraphs that were artificially split by unrecognised
-      // [[collapsible]] tokens (nested collapsible is treated as plain text)
-      bodyElements = mergeSplitParagraphs(bodyResult.elements);
+      bodyElements = bodyResult.elements;
     }
 
     // Check for missing close tag

--- a/packages/parser/src/parser/rules/block/utils.ts
+++ b/packages/parser/src/parser/rules/block/utils.ts
@@ -82,17 +82,29 @@ export function canApplyBlockRule(rule: BlockRule, token: Token): boolean {
  *
  * @param ctx            - Parse context positioned at the start of the body.
  * @param closeCondition - Predicate that signals the end of the block body.
+ * @param options        - Optional settings.
+ * @param options.excludedBlockNames - Block names that should be excluded
+ *   from both rule dispatch and paragraph-boundary detection. The named
+ *   rules are filtered out of `blockRules`, and the set is propagated to
+ *   the inline parser via `ParseContext.excludedBlockNames` so that
+ *   `BLOCK_OPEN` / `BLOCK_END_OPEN` tokens for these names do not trigger
+ *   paragraph breaks.
  * @returns Parsed elements and total tokens consumed.
  */
 export function parseBlocksUntil(
   ctx: ParseContext,
   closeCondition: (ctx: ParseContext) => boolean,
+  options?: { excludedBlockNames?: ReadonlySet<string> },
 ): BlockParseResult {
   const elements: Element[] = [];
   let consumed = 0;
   let pos = ctx.pos;
 
-  const { blockRules, blockFallbackRule } = ctx;
+  const excluded = options?.excludedBlockNames;
+  const blockRules = excluded
+    ? ctx.blockRules.filter((r) => !excluded.has(r.name))
+    : ctx.blockRules;
+  const { blockFallbackRule } = ctx;
 
   while (pos < ctx.tokens.length) {
     const token = ctx.tokens[pos];
@@ -122,8 +134,14 @@ export function parseBlocksUntil(
 
     // Try each block rule
     let matched = false;
-    // Pass close condition to context so paragraph parser can respect it
-    const blockCtx: ParseContext = { ...ctx, pos, blockCloseCondition: closeCondition };
+    // Pass close condition and excluded names to context
+    const blockCtx: ParseContext = {
+      ...ctx,
+      pos,
+      blockRules,
+      blockCloseCondition: closeCondition,
+      excludedBlockNames: excluded,
+    };
 
     for (const rule of blockRules) {
       if (canApplyBlockRule(rule, token)) {

--- a/packages/parser/src/parser/rules/inline/utils.ts
+++ b/packages/parser/src/parser/rules/inline/utils.ts
@@ -2,6 +2,19 @@ import type { TokenType, Token } from "../../../lexer";
 import type { Element } from "@wdprlib/ast";
 import type { ParseContext, InlineRule } from "../types";
 import { BLOCK_START_TOKENS } from "../../constants";
+import { parseBlockName } from "../utils";
+
+/**
+ * Checks whether the block token at `tokenPos` (BLOCK_OPEN or BLOCK_END_OPEN)
+ * names a block in the excluded set.
+ */
+function isExcludedBlockToken(ctx: ParseContext, tokenPos: number): boolean {
+  if (!ctx.excludedBlockNames?.size) return false;
+  const token = ctx.tokens[tokenPos];
+  if (token?.type !== "BLOCK_OPEN" && token?.type !== "BLOCK_END_OPEN") return false;
+  const nameResult = parseBlockName(ctx, tokenPos + 1);
+  return nameResult !== null && ctx.excludedBlockNames.has(nameResult.name);
+}
 
 /**
  * Result of parsing inline content
@@ -146,8 +159,15 @@ export function parseInlineUntil(ctx: ParseContext, endType: TokenType): InlineP
         }
       }
 
+      // Check if this block token names an excluded block (e.g. nested collapsible)
+      const isExcludedBlock =
+        (nextMeaningfulToken?.type === "BLOCK_OPEN" ||
+          nextMeaningfulToken?.type === "BLOCK_END_OPEN") &&
+        isExcludedBlockToken(ctx, pos + lookAhead);
+
       // Stop at double NEWLINE, EOF, or block start token (at line start)
-      // But don't stop at [[/span]], [[# name]], [[>/[[<, or invalid headings
+      // But don't stop at [[/span]], [[# name]], [[>/[[<, invalid headings,
+      // or excluded block names
       const isBlockStart =
         nextMeaningfulToken &&
         BLOCK_START_TOKENS.includes(nextMeaningfulToken.type) &&
@@ -155,7 +175,8 @@ export function parseInlineUntil(ctx: ParseContext, endType: TokenType): InlineP
         !isOrphanCloseSpan &&
         !isAnchorName &&
         !isInvalidBlockOpen &&
-        !isInvalidHeading;
+        !isInvalidHeading &&
+        !isExcludedBlock;
       if (
         !nextMeaningfulToken ||
         nextMeaningfulToken.type === "NEWLINE" ||

--- a/packages/parser/src/parser/rules/types.ts
+++ b/packages/parser/src/parser/rules/types.ts
@@ -26,6 +26,11 @@ export interface ParseContext {
   inlineRules: InlineRule[];
   // Close condition for current block (passed to paragraph parser)
   blockCloseCondition?: (ctx: ParseContext) => boolean;
+  // Block names excluded from paragraph-boundary detection.
+  // When a BLOCK_OPEN/BLOCK_END_OPEN for an excluded name appears at
+  // line start, the inline parser does NOT treat it as a paragraph break.
+  // Used by collapsible to prevent nested [[collapsible]] from splitting paragraphs.
+  excludedBlockNames?: ReadonlySet<string>;
   // Diagnostics collected during parsing
   diagnostics: Diagnostic[];
   // Budget for div nesting: tracks how many more nested divs can open.

--- a/tests/fixtures/collapsible/paragraph/expected.json
+++ b/tests/fixtures/collapsible/paragraph/expected.json
@@ -1,0 +1,117 @@
+{
+  "elements": [
+    {
+      "element": "collapsible",
+      "data": {
+        "elements": [
+          {
+            "element": "container",
+            "data": {
+              "type": "paragraph",
+              "attributes": {},
+              "elements": [
+                {
+                  "element": "text",
+                  "data": "文"
+                },
+                {
+                  "element": "text",
+                  "data": "章"
+                },
+                {
+                  "element": "text",
+                  "data": "1"
+                }
+              ]
+            }
+          },
+          {
+            "element": "container",
+            "data": {
+              "type": "paragraph",
+              "attributes": {},
+              "elements": [
+                {
+                  "element": "text",
+                  "data": "文"
+                },
+                {
+                  "element": "text",
+                  "data": "章"
+                },
+                {
+                  "element": "text",
+                  "data": "2"
+                }
+              ]
+            }
+          },
+          {
+            "element": "container",
+            "data": {
+              "type": "paragraph",
+              "attributes": {},
+              "elements": [
+                {
+                  "element": "text",
+                  "data": "文"
+                },
+                {
+                  "element": "text",
+                  "data": "章"
+                },
+                {
+                  "element": "text",
+                  "data": "3"
+                },
+                {
+                  "element": "line-break"
+                },
+                {
+                  "element": "text",
+                  "data": "文"
+                },
+                {
+                  "element": "text",
+                  "data": "章"
+                },
+                {
+                  "element": "text",
+                  "data": "4"
+                },
+                {
+                  "element": "line-break"
+                },
+                {
+                  "element": "text",
+                  "data": "文"
+                },
+                {
+                  "element": "text",
+                  "data": "章"
+                },
+                {
+                  "element": "text",
+                  "data": "5"
+                }
+              ]
+            }
+          }
+        ],
+        "attributes": {},
+        "start-open": false,
+        "show-text": null,
+        "hide-text": null,
+        "show-top": true,
+        "show-bottom": false
+      }
+    },
+    {
+      "element": "footnote-block",
+      "data": {
+        "title": null,
+        "hide": false
+      }
+    }
+  ]
+}

--- a/tests/fixtures/collapsible/paragraph/input.ftml
+++ b/tests/fixtures/collapsible/paragraph/input.ftml
@@ -1,0 +1,9 @@
+[[collapsible]]
+文章1
+
+文章2
+
+文章3
+文章4
+文章5
+[[/collapsible]]

--- a/tests/fixtures/collapsible/paragraph/output.html
+++ b/tests/fixtures/collapsible/paragraph/output.html
@@ -1,0 +1,11 @@
+<div class="collapsible-block">
+<div class="collapsible-block-folded"><a class="collapsible-block-link" href="javascript:;">+&nbsp;show&nbsp;block</a></div>
+<div class="collapsible-block-unfolded" style="display:none">
+<div class="collapsible-block-unfolded-link"><a class="collapsible-block-link" href="javascript:;">–&nbsp;hide&nbsp;block</a></div>
+<div class="collapsible-block-content">
+<p>文章1</p>
+<p>文章2</p>
+<p>文章3<br />文章4<br />文章5</p>
+</div>
+</div>
+</div>


### PR DESCRIPTION
## Summary
- `[[collapsible]]`内で空行による段落分け(`<p>`)が機能せず、全て`<br>`で連結されていた問題を修正
- `parseBlocksUntil`に`excludedBlockNames`オプションを追加し、ネスト不可ブロックの段落境界判定を根本的に解決
- collapsible固有の後処理(`mergeParagraphs`)を削除し、汎用的な仕組みに置き換え

## Changes
- `ParseContext`に`excludedBlockNames`フィールドを追加
- `parseBlocksUntil`がrule dispatchとcontextの両方で除外を適用
- `parseInlineUntil`が`BLOCK_OPEN`/`BLOCK_END_OPEN`の段落境界判定で除外ブロック名をスキップ
- テストフィクスチャ`collapsible/paragraph`を追加