### PR TITLE
fix(parser): footnote内の="でQUOTED_STRINGが終端を飲み込む問題を修正

### DIFF
--- a/packages/parser/src/lexer/lexer.ts
+++ b/packages/parser/src/lexer/lexer.ts
@@ -45,6 +45,15 @@ export class Lexer {
   private options: Required<LexerOptions>;
   // Positions where ]] should be split into ] + ] (for invalid anchor names)
   private splitBlockClosePositions: Set<number> = new Set();
+  /**
+   * Nesting depth of block-opener context (between `[[` / `[[/` and the
+   * matching `]]`). Used to scope `QUOTED_STRING` recognition so that
+   * `"` after `=` only becomes a quoted attribute value while we are
+   * actually parsing block attributes — otherwise inline `=` followed by
+   * `"` (e.g. inside `[[footnote]]="[[/footnote]]`) would erroneously
+   * consume content up to the next `"` or newline.
+   */
+  private blockOpenerDepth = 0;
 
   constructor(source: string, options: LexerOptions = {}) {
     this.options = {
@@ -206,6 +215,14 @@ export class Lexer {
       this.state.tokens[this.state.tokens.length - 1]?.type === "NEWLINE";
 
     this.state.tokens.push(createToken(type, value, position, lineStart));
+
+    // Track block-opener nesting so `"` after `=` is only recognised as a
+    // quoted attribute value while we are actually inside `[[ ... ]]`.
+    if (type === "BLOCK_OPEN" || type === "BLOCK_END_OPEN") {
+      this.blockOpenerDepth++;
+    } else if (type === "BLOCK_CLOSE" && this.blockOpenerDepth > 0) {
+      this.blockOpenerDepth--;
+    }
   }
 
   /**
@@ -555,10 +572,13 @@ export class Lexer {
     }
 
     // Quoted string (only after EQUALS for block attribute values)
-    // In inline context, " is just a text character (typographic quotes)
+    // In inline context (outside of a `[[...]]` opener), `"` is just a
+    // text character (typographic quote). Without the depth gate, an
+    // inline `=` followed by `"` (e.g. `[[footnote]]="[[/footnote]]`)
+    // would otherwise eat the closing tag.
     if (char === '"') {
       const lastNonWs = this.lastNonWhitespaceTokenType();
-      if (lastNonWs === "EQUALS") {
+      if (this.blockOpenerDepth > 0 && lastNonWs === "EQUALS") {
         let quoted = this.advance(); // opening "
         while (!this.isAtEnd() && this.current() !== '"' && this.current() !== "\n") {
           quoted += this.advance();

--- a/tests/fixtures/footnote/equals-ident-quote/expected.json
+++ b/tests/fixtures/footnote/equals-ident-quote/expected.json
@@ -1,0 +1,51 @@
+{
+  "elements": [
+    {
+      "element": "container",
+      "data": {
+        "type": "paragraph",
+        "attributes": {},
+        "elements": [
+          {
+            "element": "text",
+            "data": "Foo"
+          },
+          {
+            "element": "footnote"
+          },
+          {
+            "element": "text",
+            "data": " "
+          },
+          {
+            "element": "text",
+            "data": "bar"
+          }
+        ]
+      }
+    },
+    {
+      "element": "footnote-block",
+      "data": {
+        "title": null,
+        "hide": false
+      }
+    }
+  ],
+  "footnotes": [
+    [
+      {
+        "element": "text",
+        "data": "="
+      },
+      {
+        "element": "text",
+        "data": "a"
+      },
+      {
+        "element": "text",
+        "data": "\""
+      }
+    ]
+  ]
+}

--- a/tests/fixtures/footnote/equals-ident-quote/input.ftml
+++ b/tests/fixtures/footnote/equals-ident-quote/input.ftml
@@ -1,0 +1,1 @@
+Foo[[footnote]]=a"[[/footnote]] bar

--- a/tests/fixtures/footnote/equals-ident-quote/output.html
+++ b/tests/fixtures/footnote/equals-ident-quote/output.html
@@ -1,0 +1,1 @@
+<p>Foo<sup class="footnoteref"><a id="footnoteref-1" href="javascript:;" class="footnoteref">1</a></sup> bar</p><div class="footnotes-footer"><div class="title">Footnotes</div><div class="footnote-footer" id="footnote-1"><a href="javascript:;">1</a>. =a"</div></div>

--- a/tests/fixtures/footnote/equals-ident-quote/wikidot.html
+++ b/tests/fixtures/footnote/equals-ident-quote/wikidot.html
@@ -1,0 +1,5 @@
+<p>Foo<sup class="footnoteref"><a id="footnoteref-1" href="javascript:;" class="footnoteref" onclick="WIKIDOT.page.utils.scrollToReference('footnote-1')">1</a></sup> bar</p>
+<div class="footnotes-footer">
+<div class="title">Footnotes</div>
+<div class="footnote-footer" id="footnote-1"><a href="javascript:;" onclick="WIKIDOT.page.utils.scrollToReference('footnoteref-1')">1</a>. =a"</div>
+</div>

--- a/tests/fixtures/footnote/equals-quote-immediate/expected.json
+++ b/tests/fixtures/footnote/equals-quote-immediate/expected.json
@@ -1,0 +1,47 @@
+{
+  "elements": [
+    {
+      "element": "container",
+      "data": {
+        "type": "paragraph",
+        "attributes": {},
+        "elements": [
+          {
+            "element": "text",
+            "data": "Foo"
+          },
+          {
+            "element": "footnote"
+          },
+          {
+            "element": "text",
+            "data": " "
+          },
+          {
+            "element": "text",
+            "data": "bar"
+          }
+        ]
+      }
+    },
+    {
+      "element": "footnote-block",
+      "data": {
+        "title": null,
+        "hide": false
+      }
+    }
+  ],
+  "footnotes": [
+    [
+      {
+        "element": "text",
+        "data": "="
+      },
+      {
+        "element": "text",
+        "data": "\""
+      }
+    ]
+  ]
+}

--- a/tests/fixtures/footnote/equals-quote-immediate/input.ftml
+++ b/tests/fixtures/footnote/equals-quote-immediate/input.ftml
@@ -1,0 +1,1 @@
+Foo[[footnote]]="[[/footnote]] bar

--- a/tests/fixtures/footnote/equals-quote-immediate/output.html
+++ b/tests/fixtures/footnote/equals-quote-immediate/output.html
@@ -1,0 +1,1 @@
+<p>Foo<sup class="footnoteref"><a id="footnoteref-1" href="javascript:;" class="footnoteref">1</a></sup> bar</p><div class="footnotes-footer"><div class="title">Footnotes</div><div class="footnote-footer" id="footnote-1"><a href="javascript:;">1</a>. ="</div></div>

--- a/tests/fixtures/footnote/equals-quote-immediate/wikidot.html
+++ b/tests/fixtures/footnote/equals-quote-immediate/wikidot.html
@@ -1,0 +1,5 @@
+<p>Foo<sup class="footnoteref"><a id="footnoteref-1" href="javascript:;" class="footnoteref" onclick="WIKIDOT.page.utils.scrollToReference('footnote-1')">1</a></sup> bar</p>
+<div class="footnotes-footer">
+<div class="title">Footnotes</div>
+<div class="footnote-footer" id="footnote-1"><a href="javascript:;" onclick="WIKIDOT.page.utils.scrollToReference('footnoteref-1')">1</a>. ="</div>
+</div>

--- a/tests/fixtures/footnote/equals-quote-spaced/expected.json
+++ b/tests/fixtures/footnote/equals-quote-spaced/expected.json
@@ -1,0 +1,51 @@
+{
+  "elements": [
+    {
+      "element": "container",
+      "data": {
+        "type": "paragraph",
+        "attributes": {},
+        "elements": [
+          {
+            "element": "text",
+            "data": "Foo"
+          },
+          {
+            "element": "footnote"
+          },
+          {
+            "element": "text",
+            "data": " "
+          },
+          {
+            "element": "text",
+            "data": "bar"
+          }
+        ]
+      }
+    },
+    {
+      "element": "footnote-block",
+      "data": {
+        "title": null,
+        "hide": false
+      }
+    }
+  ],
+  "footnotes": [
+    [
+      {
+        "element": "text",
+        "data": "="
+      },
+      {
+        "element": "text",
+        "data": " "
+      },
+      {
+        "element": "text",
+        "data": "\""
+      }
+    ]
+  ]
+}

--- a/tests/fixtures/footnote/equals-quote-spaced/input.ftml
+++ b/tests/fixtures/footnote/equals-quote-spaced/input.ftml
@@ -1,0 +1,1 @@
+Foo[[footnote]]= "[[/footnote]] bar

--- a/tests/fixtures/footnote/equals-quote-spaced/output.html
+++ b/tests/fixtures/footnote/equals-quote-spaced/output.html
@@ -1,0 +1,1 @@
+<p>Foo<sup class="footnoteref"><a id="footnoteref-1" href="javascript:;" class="footnoteref">1</a></sup> bar</p><div class="footnotes-footer"><div class="title">Footnotes</div><div class="footnote-footer" id="footnote-1"><a href="javascript:;">1</a>. = "</div></div>

--- a/tests/fixtures/footnote/equals-quote-spaced/wikidot.html
+++ b/tests/fixtures/footnote/equals-quote-spaced/wikidot.html
@@ -1,0 +1,5 @@
+<p>Foo<sup class="footnoteref"><a id="footnoteref-1" href="javascript:;" class="footnoteref" onclick="WIKIDOT.page.utils.scrollToReference('footnote-1')">1</a></sup> bar</p>
+<div class="footnotes-footer">
+<div class="title">Footnotes</div>
+<div class="footnote-footer" id="footnote-1"><a href="javascript:;" onclick="WIKIDOT.page.utils.scrollToReference('footnoteref-1')">1</a>. = "</div>
+</div>


### PR DESCRIPTION
## Summary

- `[[footnote]]` 本文に `key="value"` のような構造があると、lexer の `QUOTED_STRING` ルールが `"` を貪欲に取り込み、`[[/footnote]]` まで一気に吸い込んで footnote の終端を見失う問題を修正。
- `QUOTED_STRING` トークン化を block opener 内 (`[[...]]`) に限定する `blockOpenerDepth` を lexer instance に追加し、inline 位置の `"` はテキストとして扱うように変更。

## Changes

- `packages/parser/src/lexer/lexer.ts`:
  - `Lexer` クラスに `blockOpenerDepth` フィールドを追加 (instance state、token 列にはリークさせない)。
  - `BLOCK_OPEN` / `BLOCK_END_OPEN` で +1、`BLOCK_CLOSE` で -1。
  - `QUOTED_STRING` の発火条件を `blockOpenerDepth > 0 && lastNonWsToken === "EQUALS"` に絞る。

## Test plan

- [x] footnote 内の `key="value"` 構造を含むケースを fixture テストに追加。
- [x] 既存の block-attribute 内 `QUOTED_STRING` (例 `[[div class="x"]]`) は回帰せず動作。
- [x] lint / format / typecheck 通過。
- [x] 全体テスト通過。
