### PR TITLE
fix(parser): インライン直後の indented block opener が paragraph に吸収される問題を修正

### DIFF
--- a/packages/parser/src/parser/constants.ts
+++ b/packages/parser/src/parser/constants.ts
@@ -105,3 +105,69 @@ export const KNOWN_BLOCK_NAMES: ReadonlySet<string> = new Set<string>([
   "gallery",
   "file",
 ]);
+
+/**
+ * Block names whose rule sets `requiresLineStart: false`, i.e. they can
+ * legitimately start a block even when the `[[...]]` opener is preceded
+ * by leading whitespace on its line.
+ *
+ * Used by the inline parser to decide whether a `\n<indent>[[name]]`
+ * sequence ends the current paragraph. Without this list, the inline
+ * parser would either:
+ *   - keep `lineStart` strict and miss legitimately-indented container
+ *     blocks (Wikidot accepts e.g. `\n     [[div_]]`); the inner block
+ *     gets absorbed into the parent paragraph as literal text, or
+ *   - drop the `lineStart` check entirely and prematurely break out of
+ *     paragraphs for `\n  [[toc]]` — a rule with `requiresLineStart: true`
+ *     would refuse the indented token, leaving the paragraph split but
+ *     the block unconsumed (literal `[[toc]]` text in a new paragraph).
+ *
+ * Each entry corresponds to a name handled by a block rule whose
+ * `requiresLineStart` is `false`. Keep this list in sync when adding or
+ * changing such rules; the inline-level constructs that happen to share
+ * `BLOCK_OPEN` (`[[span]]`, `[[image]]`, `[[user]]`, etc.) are
+ * intentionally excluded — they remain inline and should not split
+ * paragraphs based on indentation alone.
+ *
+ * Sources (block rule → handled names):
+ * - `bibliographyRule` → bibliography
+ * - `blockListRule` → ul, ol, li
+ * - `codeRule` → code
+ * - `collapsibleRule` → collapsible
+ * - `divRule` → div, div_
+ * - `embedBlockRule` → embed, embedvideo, embedaudio
+ * - `htmlRule` → html
+ * - `iframeRule` → iframe
+ * - `iftagsRule` → iftags
+ * - `mathRule` → math
+ * - `moduleRule` → module, module654
+ * - `orphanLiRule` → li (also under blockListRule)
+ * - `tableBlockRule` → table (row, cell, hcell are private to the in-table
+ *   parser, never accepted by the top-level dispatcher)
+ * - `tabviewRule` → tabview, tabs (tab is private to the in-tabview parser)
+ *
+ * `includeRule` is omitted because `[[include ...]]` is expanded as a
+ * text-level macro by `resolveIncludes` before the parser sees it.
+ */
+export const INDENT_ACCEPTING_BLOCK_NAMES: ReadonlySet<string> = new Set<string>([
+  "bibliography",
+  "ul",
+  "ol",
+  "li",
+  "code",
+  "collapsible",
+  "div",
+  "div_",
+  "embed",
+  "embedvideo",
+  "embedaudio",
+  "html",
+  "iframe",
+  "iftags",
+  "math",
+  "module",
+  "module654",
+  "table",
+  "tabview",
+  "tabs",
+]);

--- a/packages/parser/src/parser/rules/inline/utils.ts
+++ b/packages/parser/src/parser/rules/inline/utils.ts
@@ -1,7 +1,11 @@
 import type { TokenType, Token } from "../../../lexer";
 import type { Element } from "@wdprlib/ast";
 import type { ParseContext, InlineRule } from "../types";
-import { BLOCK_START_TOKENS, KNOWN_BLOCK_NAMES } from "../../constants";
+import {
+  BLOCK_START_TOKENS,
+  INDENT_ACCEPTING_BLOCK_NAMES,
+  KNOWN_BLOCK_NAMES,
+} from "../../constants";
 import { parseBlockName } from "../utils";
 
 /**
@@ -38,6 +42,24 @@ function isUnknownBlockToken(ctx: ParseContext, tokenPos: number): boolean {
     return true;
   }
   return !KNOWN_BLOCK_NAMES.has(nameResult.name);
+}
+
+/**
+ * Checks whether the block token at `tokenPos` names a block whose rule
+ * accepts leading whitespace before the opener (`requiresLineStart: false`).
+ *
+ * Used to decide whether a `\n<indent>[[name]]` sequence should end a
+ * paragraph: only when the matching block rule would actually consume
+ * the indented token. Otherwise the boundary check would split the
+ * paragraph for tokens that the block dispatcher then refuses, leaving
+ * literal `[[toc]]` text in a fresh paragraph.
+ */
+function isIndentAcceptingBlock(ctx: ParseContext, tokenPos: number): boolean {
+  const token = ctx.tokens[tokenPos];
+  if (token?.type !== "BLOCK_OPEN" && token?.type !== "BLOCK_END_OPEN") return false;
+  const nameResult = parseBlockName(ctx, tokenPos + 1);
+  if (nameResult === null) return false;
+  return INDENT_ACCEPTING_BLOCK_NAMES.has(nameResult.name);
 }
 
 /**
@@ -198,11 +220,34 @@ export function parseInlineUntil(ctx: ParseContext, endType: TokenType): InlineP
 
       // Stop at double NEWLINE, EOF, or block start token (at line start)
       // But don't stop at [[/span]], [[# name]], [[>/[[<, invalid headings,
-      // excluded block names, or unrecognized block names
+      // excluded block names, or unrecognized block names.
+      //
+      // Most block-start tokens require the strict `lineStart` flag (no
+      // leading whitespace at all): `   # one` is NOT a list item in
+      // Wikidot, `  + Heading` is NOT a heading, etc. We preserve that.
+      //
+      // A subset of `[[...]]` block constructs is the exception:
+      // their rules declare `requiresLineStart: false`, so Wikidot
+      // accepts leading whitespace before them and `[[/<name>]]` at
+      // arbitrary indentation also has to close such a block. The
+      // `lookAhead` walk above already consumed the NEWLINE and any
+      // leading WHITESPACE, so we know `nextMeaningfulToken` sits at
+      // the semantic start of the next line. We relax the `lineStart`
+      // check only when the block name's rule will actually accept the
+      // indented opener ({@link INDENT_ACCEPTING_BLOCK_NAMES});
+      // otherwise (e.g. `[[toc]]`, `[[footnoteblock]]`, align markers)
+      // the dispatcher would reject the indented token anyway and we
+      // would end up splitting the paragraph only to leave literal
+      // `[[…]]` text behind.
+      const isIndentedBlockOpener =
+        nextMeaningfulToken &&
+        (nextMeaningfulToken.type === "BLOCK_OPEN" ||
+          nextMeaningfulToken.type === "BLOCK_END_OPEN") &&
+        isIndentAcceptingBlock(ctx, pos + lookAhead);
       const isBlockStart =
         nextMeaningfulToken &&
         BLOCK_START_TOKENS.includes(nextMeaningfulToken.type) &&
-        nextMeaningfulToken.lineStart &&
+        (nextMeaningfulToken.lineStart || isIndentedBlockOpener) &&
         !isOrphanCloseSpan &&
         !isAnchorName &&
         !isInvalidBlockOpen &&

--- a/tests/fixtures/div/indented-nested-after-inline/expected.json
+++ b/tests/fixtures/div/indented-nested-after-inline/expected.json
@@ -1,0 +1,44 @@
+{
+  "elements": [
+    {
+      "element": "container",
+      "data": {
+        "type": "div",
+        "attributes": {
+          "class": "outer"
+        },
+        "elements": [
+          {
+            "element": "link",
+            "data": {
+              "type": "direct",
+              "link": "/url",
+              "extra": null,
+              "label": {
+                "text": "label"
+              },
+              "target": null
+            }
+          },
+          {
+            "element": "container",
+            "data": {
+              "type": "div",
+              "attributes": {
+                "class": "inner"
+              },
+              "elements": []
+            }
+          }
+        ]
+      }
+    },
+    {
+      "element": "footnote-block",
+      "data": {
+        "title": null,
+        "hide": false
+      }
+    }
+  ]
+}

--- a/tests/fixtures/div/indented-nested-after-inline/input.ftml
+++ b/tests/fixtures/div/indented-nested-after-inline/input.ftml
@@ -1,0 +1,5 @@
+[[div_ class="outer"]]
+[/url label]
+     [[div_ class="inner"]]
+     [[/div]]
+[[/div]]

--- a/tests/fixtures/div/indented-nested-after-inline/output.html
+++ b/tests/fixtures/div/indented-nested-after-inline/output.html
@@ -1,0 +1,1 @@
+<div class="outer"><a href="/url">label</a><div class="inner"></div></div>


### PR DESCRIPTION
## Summary

- 段落のインライン内容の直後に空白インデント + ブロック opener (`  [[div]]` 等) が来ると、その block が新しい段落境界として認識されず、開きトークンが直前の paragraph 末尾の inline テキストに吸収されていた問題を修正。
- インライン解析側で「インデント許容のブロック opener」を段落境界扱いするための allowlist `INDENT_ACCEPTING_BLOCK_NAMES` を導入。

## Changes

- `packages/parser/src/parser/constants.ts`:
  - `INDENT_ACCEPTING_BLOCK_NAMES` Set を追加 (`div`, `div_`, `collapsible`, `code`, `html`, `iftags`, `iframe`, `math`, `module`, `module654`, `bibliography`, `ul`, `ol`, `li`, `table`, `tabview`, `tabs`, `embed`, `embedvideo`, `embedaudio`)。`row` / `cell` / `hcell` / `tab` は意図的に除外 (これらは親 block 内部の構成要素で、線頭からは現れない)。
- `packages/parser/src/parser/rules/inline/utils.ts`:
  - `isIndentAcceptingBlock` ヘルパで判定。
  - paragraph 解析中の `isBlockStart` で、line-start チェックを INDENT_ACCEPTING_BLOCK_NAMES に限り緩和。

## Test plan

- [x] インライン直後に空白インデント + nested block が来るケースを fixture テストに追加。
- [x] 行頭の block opener (インデントなし) は従来挙動を維持。
- [x] INDENT_ACCEPTING_BLOCK_NAMES に含まれない block 名は影響なし。
- [x] lint / format / typecheck 通過。
- [x] 全体テスト通過。