### PR TITLE
fix(runtime): 狭い viewport で footnote tooltip がはみ出る問題を修正

### DIFF
--- a/packages/runtime/src/footnote.ts
+++ b/packages/runtime/src/footnote.ts
@@ -142,6 +142,15 @@ function positionTooltip(tip: HTMLElement, anchor: HTMLElement): void {
   const win = doc.defaultView ?? window;
   const anchorRect = anchor.getBoundingClientRect();
 
+  const margin = 8;
+
+  // Cap the tooltip width to the viewport before measuring. On narrow
+  // (mobile) screens a long footnote would otherwise render a tooltip
+  // wider than the screen; the horizontal clamps below cannot recover
+  // from that because there is no position at which an over-wide box
+  // fits, so it always bleeds past one edge.
+  tip.style.maxWidth = `${Math.max(0, win.innerWidth - margin * 2)}px`;
+
   let left = anchorRect.left + win.scrollX;
   let top = anchorRect.bottom + win.scrollY + 4;
 
@@ -150,8 +159,14 @@ function positionTooltip(tip: HTMLElement, anchor: HTMLElement): void {
   const tipRect = tip.getBoundingClientRect();
   tip.style.display = "none";
 
+  // Pull left so the right edge stays inside the viewport...
   if (left + tipRect.width > win.innerWidth + win.scrollX) {
-    left = win.innerWidth + win.scrollX - tipRect.width - 8;
+    left = win.innerWidth + win.scrollX - tipRect.width - margin;
+  }
+  // ...but never past the left margin (the right-edge clamp can push
+  // `left` negative when the tooltip is nearly viewport-wide).
+  if (left < win.scrollX + margin) {
+    left = win.scrollX + margin;
   }
   if (top + tipRect.height > win.innerHeight + win.scrollY) {
     top = anchorRect.top + win.scrollY - tipRect.height - 4;

--- a/packages/runtime/src/utils/tooltip.ts
+++ b/packages/runtime/src/utils/tooltip.ts
@@ -37,21 +37,31 @@ export function showTooltipEl(anchor: HTMLElement, tip: HTMLElement): void {
   hideTooltip();
 
   const doc = anchor.ownerDocument;
+  const win = doc.defaultView ?? window;
+  const margin = 8;
 
   tip.style.position = "absolute";
   tip.style.zIndex = "10000";
+  // Cap width to the viewport before measuring so wide content cannot
+  // overflow on narrow (mobile) screens — the horizontal clamps below
+  // cannot place an over-wide box without it bleeding past an edge.
+  tip.style.maxWidth = `${Math.max(0, win.innerWidth - margin * 2)}px`;
   doc.body.appendChild(tip);
 
   const anchorRect = anchor.getBoundingClientRect();
   const tipRect = tip.getBoundingClientRect();
-  const win = doc.defaultView ?? window;
 
   let left = anchorRect.left + win.scrollX;
   let top = anchorRect.bottom + win.scrollY + 4;
 
-  // Keep within viewport
+  // Keep right edge within viewport...
   if (left + tipRect.width > win.innerWidth + win.scrollX) {
-    left = win.innerWidth + win.scrollX - tipRect.width - 8;
+    left = win.innerWidth + win.scrollX - tipRect.width - margin;
+  }
+  // ...but never past the left margin (right-edge clamp can push `left`
+  // negative when the tooltip is nearly viewport-wide).
+  if (left < win.scrollX + margin) {
+    left = win.scrollX + margin;
   }
   if (top + tipRect.height > win.innerHeight + win.scrollY) {
     top = anchorRect.top + win.scrollY - tipRect.height - 4;

--- a/packages/runtime/tests/footnote.test.ts
+++ b/packages/runtime/tests/footnote.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+
+/**
+ * Regression coverage for footnote tooltip positioning on narrow
+ * (mobile) viewports.
+ *
+ * happy-dom has no layout engine, so `getBoundingClientRect()` returns
+ * zeros by default. We stub the anchor's and tooltip's rects, and the
+ * window's `innerWidth`, to drive the clamp logic in `initFootnote`'s
+ * `positionTooltip` deterministically.
+ */
+describe("footnote tooltip positioning", () => {
+  let happyWindow: Window;
+  let doc: Document;
+  let root: HTMLElement;
+  let originalWindow: typeof globalThis.window | undefined;
+  let originalNode: unknown;
+
+  beforeEach(() => {
+    happyWindow = new Window();
+    doc = happyWindow.document as unknown as Document;
+    root = doc.createElement("div");
+    doc.body.appendChild(root);
+    originalWindow = globalThis.window;
+    // @ts-expect-error - assign happy-dom window to global
+    globalThis.window = happyWindow;
+    // The source uses the global `Node` constant (browser global);
+    // expose happy-dom's so `Node.TEXT_NODE` resolves under the test.
+    originalNode = (globalThis as { Node?: unknown }).Node;
+    (globalThis as { Node?: unknown }).Node = happyWindow.Node;
+  });
+
+  afterEach(() => {
+    if (originalWindow !== undefined) {
+      globalThis.window = originalWindow;
+    }
+    (globalThis as { Node?: unknown }).Node = originalNode;
+  });
+
+  /** Force `window.innerWidth` (happy-dom defaults to 1024). */
+  function setViewportWidth(width: number): void {
+    Object.defineProperty(happyWindow, "innerWidth", {
+      value: width,
+      configurable: true,
+    });
+  }
+
+  /** Stub an element's bounding rect with the given left/width. */
+  function stubRect(el: Element, rect: Partial<DOMRect>): void {
+    el.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        ...rect,
+      }) as DOMRect;
+  }
+
+  test("caps tooltip max-width to the viewport on a narrow screen", async () => {
+    const { initFootnote } = await import("../src/footnote");
+
+    // 320px-wide mobile viewport
+    setViewportWidth(320);
+
+    root.innerHTML =
+      `Body<sup class="footnoteref">` +
+      `<a id="footnoteref-1" href="#footnote-1" class="footnoteref">1</a></sup>` +
+      `<div class="footnotes-footer">` +
+      `<div class="footnote-footer" id="footnote-1">` +
+      `<a href="javascript:;">1</a>. ${"long ".repeat(80)}</div></div>`;
+
+    const cleanup = initFootnote(root);
+
+    const fref = root.querySelector<HTMLAnchorElement>("a.footnoteref")!;
+    stubRect(fref, { left: 300, right: 310, bottom: 20, top: 10, width: 10, height: 10 });
+
+    const tip = doc.getElementById("odialog-hovertips")!.querySelector<HTMLElement>(".hovertip")!;
+    stubRect(tip, { width: 300, height: 100 });
+
+    fref.dispatchEvent(
+      new happyWindow.MouseEvent("mouseenter", { bubbles: true }) as unknown as Event,
+    );
+
+    // Width is capped to the viewport minus the two margins.
+    expect(tip.style.maxWidth).toBe(`${320 - 8 * 2}px`);
+
+    cleanup.destroy();
+  });
+
+  test("clamps left to the margin when the right-edge clamp would go negative", async () => {
+    const { initFootnote } = await import("../src/footnote");
+
+    // 320px-wide mobile viewport. With a measured tooltip wider than
+    // `innerWidth - 2*margin` (= 304), the right-edge clamp alone yields
+    // `left = 320 - 318 - 8 = -6`, which would bleed off the left edge.
+    // The left-edge clamp must pull it back to the margin.
+    setViewportWidth(320);
+
+    root.innerHTML =
+      `Body<sup class="footnoteref">` +
+      `<a id="footnoteref-1" href="#footnote-1" class="footnoteref">1</a></sup>` +
+      `<div class="footnotes-footer">` +
+      `<div class="footnote-footer" id="footnote-1">` +
+      `<a href="javascript:;">1</a>. ${"long ".repeat(80)}</div></div>`;
+
+    const cleanup = initFootnote(root);
+
+    const fref = root.querySelector<HTMLAnchorElement>("a.footnoteref")!;
+    stubRect(fref, { left: 300, right: 310, bottom: 20, top: 10, width: 10, height: 10 });
+
+    const tip = doc.getElementById("odialog-hovertips")!.querySelector<HTMLElement>(".hovertip")!;
+    // Wider than innerWidth - 2*margin so the right-edge clamp underflows.
+    stubRect(tip, { width: 318, height: 100 });
+
+    fref.dispatchEvent(
+      new happyWindow.MouseEvent("mouseenter", { bubbles: true }) as unknown as Event,
+    );
+
+    const margin = 8;
+    // Left edge pinned to the margin (without the fix this would be -6).
+    expect(parseFloat(tip.style.left)).toBe(margin);
+
+    cleanup.destroy();
+  });
+
+  test("does not over-constrain on a wide screen", async () => {
+    const { initFootnote } = await import("../src/footnote");
+
+    setViewportWidth(1200);
+
+    root.innerHTML =
+      `Body<sup class="footnoteref">` +
+      `<a id="footnoteref-1" href="#footnote-1" class="footnoteref">1</a></sup>` +
+      `<div class="footnotes-footer">` +
+      `<div class="footnote-footer" id="footnote-1"><a href="javascript:;">1</a>. short</div></div>`;
+
+    const cleanup = initFootnote(root);
+
+    const fref = root.querySelector<HTMLAnchorElement>("a.footnoteref")!;
+    stubRect(fref, { left: 100, right: 110, bottom: 20, top: 10, width: 10, height: 10 });
+
+    const tip = doc.getElementById("odialog-hovertips")!.querySelector<HTMLElement>(".hovertip")!;
+    stubRect(tip, { width: 200, height: 80 });
+
+    fref.dispatchEvent(
+      new happyWindow.MouseEvent("mouseenter", { bubbles: true }) as unknown as Event,
+    );
+
+    // Anchored at its natural left position (100); fits without clamping.
+    expect(parseFloat(tip.style.left)).toBe(100);
+
+    cleanup.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

- スマートフォン等の狭い viewport で長文 footnote の tooltip を開くと、tooltip がコンテナ幅を超えて右側にはみ出し、画面端を突き抜けることがあった問題を修正。
- tooltip の `maxWidth` を viewport - margin*2 で制約し、`left` を viewport 左端 - margin で下限 clamp。

## Changes

- `packages/runtime/src/utils/tooltip.ts` (および `footnote.ts` 経由):
  - tooltip の幅を `tip.style.maxWidth = ${Math.max(0, win.innerWidth - margin*2)}px` で制限。
  - 左端の clamp: `if (left < win.scrollX + margin) left = win.scrollX + margin`。
- happy-dom ベースの DOM テスト追加 (`stubRect`、`setViewportWidth`、`globalThis.Node` セットアップ)。

## Test plan

- [x] 狭 viewport (例 320px) で長文 footnote tooltip を開いてもはみ出さないことを runtime ユニットテストで確認。
- [x] 通常幅の viewport では従来通りの位置・幅で表示されることを確認。
- [x] lint / format / typecheck 通過。
- [x] 全体テスト通過。