### PR TITLE
fix(render): style属性内のurl()を安全なschemeで許可

### DIFF
--- a/packages/render/src/escape.ts
+++ b/packages/render/src/escape.ts
@@ -488,13 +488,136 @@ function normalizeCssValue(value: string): string {
 }
 
 /**
+ * Allowlist check for a raw URL string extracted from a `url(...)` token.
+ *
+ * Wikidot itself allows arbitrary URLs (including `javascript:` and
+ * `expression()`) in `style` attributes, but we cannot match that
+ * exactly without re-introducing XSS. The schemes permitted below are
+ * the ones a CSS-side `url(...)` needs to actually fetch an image or
+ * background — anything else either has no visual effect or carries
+ * code-execution risk:
+ *
+ * - `http://`, `https://`, `//host/...` — load over the network.
+ * - `/path`, `./path`, `../path` — load relative to the document.
+ * - `#fragment` — same-document SVG / gradient reference.
+ * - `data:image/{png,jpeg,jpg,gif,webp}` — inline raster image.
+ *   SVG is excluded because SVG documents can embed `<script>` and
+ *   event handlers; treating an inline SVG as a `url()` payload is
+ *   indistinguishable from running attacker-supplied JavaScript.
+ *
+ * Everything else (`javascript:`, `vbscript:`, `data:text/...`,
+ * `data:application/...`, `data:image/svg+xml`) is rejected — those
+ * payloads either execute scripts directly or are interpreted as
+ * markup that can host them.
+ *
+ * The input is assumed to come from a normalised CSS value (escapes,
+ * comments, whitespace, control chars stripped and lowercased), so this
+ * function only needs to handle surrounding `"` / `'` quotes.
+ */
+function isUrlAllowed(rawUrl: string): boolean {
+  let url = rawUrl;
+
+  // Strip a single layer of matched surrounding quotes if present
+  if (url.length >= 2) {
+    const first = url[0];
+    const last = url[url.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      url = url.slice(1, -1);
+    }
+  }
+
+  // Empty url() is treated as harmless (Wikidot pass-through)
+  if (url === "") return true;
+
+  // Fragment
+  if (url.startsWith("#")) return true;
+
+  // Path-relative
+  if (url.startsWith("./") || url.startsWith("../")) return true;
+
+  // Protocol-relative `//host/...`
+  if (url.startsWith("//")) return true;
+
+  // Root-relative `/path`. Does not match `//` (handled above).
+  if (url.startsWith("/")) return true;
+
+  if (url.startsWith("http://") || url.startsWith("https://")) return true;
+
+  // data: URLs — only raster image MIME types.
+  // Match `data:image/<mime>` followed by `;` (params) or `,` (start of data),
+  // so `data:image/png+xml` or `data:image/pngsomething` cannot sneak through
+  // the allowlist with a misleading prefix.
+  if (url.startsWith("data:image/")) {
+    const after = url.slice("data:image/".length);
+    const sep = Math.min(
+      after.indexOf(";") === -1 ? after.length : after.indexOf(";"),
+      after.indexOf(",") === -1 ? after.length : after.indexOf(","),
+    );
+    const mime = after.slice(0, sep);
+    if (mime === "png" || mime === "jpeg" || mime === "jpg" || mime === "gif" || mime === "webp") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Extract every `url(...)` invocation from a normalised CSS value and
+ * yield each raw inner string (parentheses excluded).
+ *
+ * The walker tracks `"` and `'` quoted regions so that `)` inside a
+ * quoted URL string (e.g. `url("https://example.com/a)b.png")`) does
+ * not close the `url(` prematurely. Within a quoted region paren
+ * tracking is suspended.
+ *
+ * Returns an iterator of `{ inner, malformed }` records. `malformed`
+ * is `true` when a `url(` had no matching closing `)`, which the
+ * caller should treat as dangerous (fail-closed).
+ */
+function* iterateUrls(normalized: string): Generator<{ inner: string; malformed: boolean }> {
+  let searchPos = 0;
+  while (searchPos < normalized.length) {
+    const idx = normalized.indexOf("url(", searchPos);
+    if (idx === -1) return;
+
+    let depth = 1;
+    let quoteChar: string | null = null;
+    let i = idx + 4;
+    while (i < normalized.length && depth > 0) {
+      const ch = normalized[i];
+      if (quoteChar !== null) {
+        if (ch === quoteChar) quoteChar = null;
+      } else if (ch === '"' || ch === "'") {
+        quoteChar = ch;
+      } else if (ch === "(") {
+        depth++;
+      } else if (ch === ")") {
+        depth--;
+      }
+      i++;
+    }
+
+    if (depth > 0) {
+      // Unclosed url(
+      yield { inner: normalized.slice(idx + 4), malformed: true };
+      return;
+    }
+
+    yield { inner: normalized.slice(idx + 4, i - 1), malformed: false };
+    searchPos = i;
+  }
+}
+
+/**
  * Check whether a CSS property value contains dangerous patterns that
  * could enable script execution or external resource loading.
  *
  * The value is first normalized via `normalizeCssValue()` to resolve
  * CSS escapes and comments, then checked against a blocklist:
- * - `url()` -- blocks all URL-based loading (images, fonts, cursors)
- *   because even image URLs can leak data or trigger requests
+ * - `url(...)` -- only allowed when the inner URL passes
+ *   {@link isUrlAllowed} (raster images, http(s), relative paths).
+ *   Malformed `url(` (no closing paren) is treated as dangerous.
  * - `expression()` -- blocks IE's CSS expression evaluation
  * - `-moz-binding` -- blocks Firefox XBL binding injection
  * - `behavior:` -- blocks IE behavior attachment
@@ -506,8 +629,10 @@ function normalizeCssValue(value: string): string {
 export function isDangerousCssValue(value: string): boolean {
   const normalized = normalizeCssValue(value);
 
-  // Block ALL url() - prevents all URL-based attacks
-  if (normalized.includes("url(")) return true;
+  for (const { inner, malformed } of iterateUrls(normalized)) {
+    if (malformed) return true;
+    if (!isUrlAllowed(inner)) return true;
+  }
 
   // Block expression() (IE)
   if (normalized.includes("expression(")) return true;
@@ -541,13 +666,65 @@ export function isDangerousCssValue(value: string): boolean {
  * @returns The sanitized style string with dangerous declarations removed,
  *   or an empty string if nothing is safe.
  */
+/**
+ * Split a CSS style attribute value into individual declarations,
+ * respecting parentheses and quoted strings.
+ *
+ * A simple `split(";")` would corrupt declarations whose value
+ * contains `;` inside a `url(...)` invocation, e.g. a base64 data URL
+ * passed via a CSS custom property:
+ *
+ * ```css
+ * --logo: url(data:image/png;base64,iVBORw0KGgo...)
+ * ```
+ *
+ * This walker only splits on `;` when not inside `(...)` and not inside
+ * a `"..."` / `'...'` string.
+ */
+function splitDeclarations(style: string): string[] {
+  const out: string[] = [];
+  let buf = "";
+  let parenDepth = 0;
+  let quoteChar: string | null = null;
+
+  for (const ch of style) {
+    if (quoteChar !== null) {
+      buf += ch;
+      if (ch === quoteChar) quoteChar = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quoteChar = ch;
+      buf += ch;
+      continue;
+    }
+    if (ch === "(") {
+      parenDepth++;
+      buf += ch;
+      continue;
+    }
+    if (ch === ")") {
+      if (parenDepth > 0) parenDepth--;
+      buf += ch;
+      continue;
+    }
+    if (ch === ";" && parenDepth === 0) {
+      out.push(buf);
+      buf = "";
+      continue;
+    }
+    buf += ch;
+  }
+  if (buf.length > 0) out.push(buf);
+  return out;
+}
+
 export function sanitizeStyleValue(style: string): string {
   // Remember if original ends with semicolon (Wikidot preserves this)
   const endsWithSemicolon = style.trimEnd().endsWith(";");
 
-  // Split by semicolon into individual declarations
-  const declarations = style
-    .split(";")
+  // Split by semicolon (respecting parens/quotes) into individual declarations
+  const declarations = splitDeclarations(style)
     .map((d) => d.trim())
     .filter(Boolean);
   const safe: string[] = [];
@@ -556,15 +733,18 @@ export function sanitizeStyleValue(style: string): string {
     const colonIdx = decl.indexOf(":");
     if (colonIdx === -1) continue;
 
-    const property = decl.slice(0, colonIdx).trim().toLowerCase();
+    const property = decl.slice(0, colonIdx).trim();
     const value = decl.slice(colonIdx + 1).trim();
 
     // Skip if value contains dangerous patterns
     if (isDangerousCssValue(value)) continue;
 
-    // Skip dangerous properties
-    if (property.startsWith("-moz-binding")) continue;
-    if (property === "behavior") continue;
+    // Skip dangerous properties. CSS allows escape sequences inside
+    // property names too (e.g. `-mo\7a-binding` → `-moz-binding`), so we
+    // run them through the same normaliser as values before matching.
+    const normalisedProperty = normalizeCssValue(property);
+    if (normalisedProperty.startsWith("-moz-binding")) continue;
+    if (normalisedProperty === "behavior") continue;
 
     // Keep original format (Wikidot outputs input as is)
     safe.push(decl);

--- a/tests/unit/render/escape.test.ts
+++ b/tests/unit/render/escape.test.ts
@@ -517,42 +517,89 @@ describe("sanitizeCssColor", () => {
 });
 
 describe("isDangerousCssValue", () => {
-  it("should detect ALL url()", () => {
+  it("should detect dangerous url() schemes", () => {
     expect(isDangerousCssValue("url(javascript:alert(1))")).toBe(true);
     expect(isDangerousCssValue("url('javascript:alert(1)')")).toBe(true);
     expect(isDangerousCssValue("url(data:text/html,<script>)")).toBe(true);
-    // Even safe-looking URLs are blocked
-    expect(isDangerousCssValue("url(http://example.com/image.png)")).toBe(true);
+    expect(isDangerousCssValue("url(vbscript:msgbox(1))")).toBe(true);
+    expect(isDangerousCssValue("url(data:application/javascript,alert(1))")).toBe(true);
+    // SVG via data: can execute JS through embedded <script>
+    expect(isDangerousCssValue("url(data:image/svg+xml,<svg onload=alert(1)></svg>)")).toBe(true);
+    // unknown / opaque schemes also rejected
+    expect(isDangerousCssValue("url(x)")).toBe(true);
+    expect(isDangerousCssValue("url(ftp://example.com/foo)")).toBe(true);
   });
 
-  it("should detect CSS escape bypass attempts", () => {
+  it("should allow safe url() schemes", () => {
+    expect(isDangerousCssValue("url(http://example.com/files/foo.png)")).toBe(false);
+    expect(isDangerousCssValue("url(https://example.org/files/foo.png)")).toBe(false);
+    expect(isDangerousCssValue("url(//cdn.example.com/foo.png)")).toBe(false);
+    expect(isDangerousCssValue("url(/local--files/foo.png)")).toBe(false);
+    expect(isDangerousCssValue("url(./foo.png)")).toBe(false);
+    expect(isDangerousCssValue("url(../foo.png)")).toBe(false);
+    expect(isDangerousCssValue("url(#anchor)")).toBe(false);
+    expect(isDangerousCssValue("url(data:image/png;base64,iVBORw0KGgo)")).toBe(false);
+    expect(isDangerousCssValue("url(data:image/jpeg;base64,/9j/4AAQ)")).toBe(false);
+    expect(isDangerousCssValue("url(data:image/gif;base64,R0lGODlh)")).toBe(false);
+    expect(isDangerousCssValue("url(data:image/webp;base64,UklGR)")).toBe(false);
+    // Quoted variants
+    expect(isDangerousCssValue("url('http://example.com/image.png')")).toBe(false);
+    expect(isDangerousCssValue('url("http://example.com/image.png")')).toBe(false);
+  });
+
+  it("should fail-closed on malformed url(", () => {
+    // Unclosed url(
+    expect(isDangerousCssValue("url(")).toBe(true);
+    expect(isDangerousCssValue("url(http://example.com")).toBe(true);
+  });
+
+  it("should reject data:image MIME boundary tricks", () => {
+    // data:image/png<something> must NOT match the png allowlist entry
+    expect(isDangerousCssValue("url(data:image/png+xml,<svg onload=alert(1)></svg>)")).toBe(true);
+    expect(isDangerousCssValue("url(data:image/pnganything,foo)")).toBe(true);
+    expect(isDangerousCssValue("url(data:image/svg+xml,<svg/>)")).toBe(true);
+    // Boundary at `;` or `,` only — both forms must work with allowed MIME
+    expect(isDangerousCssValue("url(data:image/png;base64,iVBORw0)")).toBe(false);
+    expect(isDangerousCssValue("url(data:image/png,iVBORw0)")).toBe(false);
+  });
+
+  it("should respect quoted strings inside url(", () => {
+    // `)` inside a quoted URL value must not terminate url( early.
+    // (The value itself is unusual but should be accepted because the
+    // scheme is http; we test that the walker correctly extracts the
+    // full inner string.)
+    expect(isDangerousCssValue('url("http://example.com/a)b.png")')).toBe(false);
+    expect(isDangerousCssValue("url('http://example.com/a)b.png')")).toBe(false);
+  });
+
+  it("should detect CSS escape bypass attempts on dangerous schemes", () => {
     // \72 = 'r' in hex, so u\72l( = url(
-    expect(isDangerousCssValue("u\\72l(http://evil.com)")).toBe(true);
+    expect(isDangerousCssValue("u\\72l(javascript:alert(1))")).toBe(true);
     // \75 = 'u' in hex
-    expect(isDangerousCssValue("\\75rl(http://evil.com)")).toBe(true);
+    expect(isDangerousCssValue("\\75rl(javascript:alert(1))")).toBe(true);
     // expression with escapes
     expect(isDangerousCssValue("e\\78pression(alert(1))")).toBe(true);
   });
 
   it("should detect uppercase hex escape bypass attempts", () => {
     // \55 = 'U' (uppercase), must be lowercased after decode
-    expect(isDangerousCssValue("\\55rl(http://evil.com)")).toBe(true);
+    expect(isDangerousCssValue("\\55rl(javascript:alert(1))")).toBe(true);
     // \55\52\4c = URL (uppercase)
-    expect(isDangerousCssValue("\\55\\52\\4c(http://evil.com)")).toBe(true);
+    expect(isDangerousCssValue("\\55\\52\\4c(javascript:alert(1))")).toBe(true);
   });
 
   it("should detect CSS line continuation bypass attempts", () => {
     // Backslash + newline is removed in CSS
-    expect(isDangerousCssValue("u\\\nrl(http://evil.com)")).toBe(true);
-    expect(isDangerousCssValue("u\\\rrl(http://evil.com)")).toBe(true);
-    expect(isDangerousCssValue("u\\\r\nrl(http://evil.com)")).toBe(true);
+    expect(isDangerousCssValue("u\\\nrl(javascript:alert(1))")).toBe(true);
+    expect(isDangerousCssValue("u\\\rrl(javascript:alert(1))")).toBe(true);
+    expect(isDangerousCssValue("u\\\r\nrl(javascript:alert(1))")).toBe(true);
     expect(isDangerousCssValue("@im\\\nport 'evil.css'")).toBe(true);
   });
 
   it("should detect CSS comment bypass attempts", () => {
     // u/**/rl( = url(
-    expect(isDangerousCssValue("u/**/rl(http://evil.com)")).toBe(true);
-    expect(isDangerousCssValue("ur/*comment*/l(http://evil.com)")).toBe(true);
+    expect(isDangerousCssValue("u/**/rl(javascript:alert(1))")).toBe(true);
+    expect(isDangerousCssValue("ur/*comment*/l(javascript:alert(1))")).toBe(true);
     // @im/**/port = @import
     expect(isDangerousCssValue("@im/**/port 'evil.css'")).toBe(true);
   });
@@ -593,12 +640,45 @@ describe("sanitizeStyleValue", () => {
     );
   });
 
+  it("should preserve safe url() declarations", () => {
+    expect(
+      sanitizeStyleValue("background: url(http://example.com/files/foo.png) center/cover"),
+    ).toBe("background: url(http://example.com/files/foo.png) center/cover");
+    expect(sanitizeStyleValue("background-image: url(/local--files/foo.png)")).toBe(
+      "background-image: url(/local--files/foo.png)",
+    );
+  });
+
+  it("should preserve CSS custom properties with url()", () => {
+    // A custom property declaration like `--logo: url(...)` must survive
+    // sanitization intact so a downstream rule using `var(--logo)`
+    // (e.g. `background: var(--logo)`) can resolve to the image URL.
+    expect(sanitizeStyleValue("--logo: url(http://example.com/local--files/foo.png)")).toBe(
+      "--logo: url(http://example.com/local--files/foo.png)",
+    );
+  });
+
+  it("should preserve data:image URLs containing semicolons", () => {
+    // Base64 data URLs contain `;base64` -- declaration splitter must not split here
+    expect(sanitizeStyleValue("background: url(data:image/png;base64,iVBORw0KGgo)")).toBe(
+      "background: url(data:image/png;base64,iVBORw0KGgo)",
+    );
+  });
+
   it("should remove expression()", () => {
     expect(sanitizeStyleValue("width: expression(alert(1))")).toBe("");
   });
 
   it("should remove -moz-binding", () => {
     expect(sanitizeStyleValue("-moz-binding: url(x)")).toBe("");
+  });
+
+  it("should remove escaped dangerous property names", () => {
+    // `\7a` decodes to `z`, so `-mo\7a-binding` == `-moz-binding`.
+    // Pair with a value that would otherwise be allowed (so the only
+    // line of defense is the property-name check).
+    expect(sanitizeStyleValue("-mo\\7a-binding: url(http://example.com/files/foo.png)")).toBe("");
+    expect(sanitizeStyleValue("beh\\61vior: url(http://example.com/files/foo.png)")).toBe("");
   });
 
   it("should handle empty input", () => {


### PR DESCRIPTION
## Summary

- インライン style 属性内の `url()` を以前は実質ブロックしており、`background-image: url(...)` などの一般的な CSS 値が壊れていた問題を修正。
- 既存の XSS / インジェクション対策を残しつつ、`url()` の引数 scheme を allowlist 化し、`http(s):` / `data:image/{png,jpeg,jpg,gif,webp}` のみを許可。`svg` 等 active content を含み得るものは引き続き拒否。

## Changes

- `packages/render/src/escape.ts`:
  - `isUrlAllowed(url)` を追加。`http://` / `https://` / `data:image/png|jpeg|jpg|gif|webp` (base64 / 直接) を許可、それ以外 (`javascript:`、`data:image/svg+xml`、`data:text/*` 等) は拒否。
  - `iterateUrls()` で `url(...)` を抽出し各引数を `isUrlAllowed` でチェック。
  - `splitDeclarations()` を改善: paren / quote を尊重して `;` で分割 (これまで naïve な split で誤分割していた)。
  - property 名は `normalizeCssValue` で正規化してから `-moz-binding` / `behavior` の deny list と照合 (case folding / 全角混入 対策)。

## Test plan

- [x] `background-image: url("https://example.com/x.png")` が通る。
- [x] `background-image: url(data:image/png;base64,...)` が通る。
- [x] `background-image: url(javascript:alert(1))` が拒否される。
- [x] `background-image: url(data:image/svg+xml;...)` が拒否される。
- [x] 複数 declaration / quote 内 `;` などのエッジが正しく分割される回帰テスト。
- [x] lint / format / typecheck 通過。
- [x] 全体テスト通過。
