### PR TITLE
fix(parser): include の初期値代入イディオムが効かない問題を修正

### DIFF
--- a/packages/parser/src/parser/rules/block/module/include/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/include/resolve.ts
@@ -202,15 +202,47 @@ function parseIncludeDirective(inner: string): { location: PageRef; variables: V
     }
   }
 
+  // Build the variable map, honouring Wikidot's default-value idiom.
+  //
+  // A template supplies a default for a forwarded variable by repeating
+  // the key: `key={$key} | key=default`. Once the outer include has
+  // substituted `{$key}`, that segment pair becomes one of:
+  //   - `key=value | key=default`        (caller supplied a value)
+  //   - `key= | key=default`             (caller passed an empty value)
+  //   - `key={$key} | key=default`       (caller omitted it; placeholder
+  //                                        left unresolved)
+  // The intended result is "use the caller's value if present, else the
+  // default", so the FIRST *concrete* value for a key wins. An empty
+  // string or a still-unresolved `{$...}` placeholder is not concrete and
+  // lets a later default apply.
+  //
+  // A key seen only with empty/placeholder values keeps that (empty or
+  // literal) value, preserving the existing pass-through behaviour for
+  // genuinely unset variables.
   const variables: VariableMap = {};
+  const hasConcrete = new Set<string>();
   for (const segment of varSegments) {
     const eqIndex = segment.indexOf("=");
-    if (eqIndex !== -1) {
-      const key = segment.slice(0, eqIndex).trim();
-      const value = segment.slice(eqIndex + 1).trim();
-      if (key) {
+    if (eqIndex === -1) continue;
+    const key = segment.slice(0, eqIndex).trim();
+    if (!key) continue;
+    const value = segment.slice(eqIndex + 1).trim();
+
+    const isPlaceholder = /^\{\$[^}]*\}$/.test(value);
+    const isConcrete = value !== "" && !isPlaceholder;
+
+    if (isConcrete) {
+      if (!hasConcrete.has(key)) {
         variables[key] = value;
+        hasConcrete.add(key);
       }
+      // A later concrete value for the same key is a default; ignore it.
+    } else if (!Object.hasOwn(variables, key)) {
+      // First empty/placeholder occurrence — keep it unless a concrete
+      // value (earlier or later) replaces it via the branch above.
+      // `Object.hasOwn` (not `in`) so keys like `toString` / `constructor`
+      // are not mistaken for already-present via the prototype chain.
+      variables[key] = value;
     }
   }
 

--- a/tests/unit/module/include/resolve.test.ts
+++ b/tests/unit/module/include/resolve.test.ts
@@ -229,6 +229,58 @@ describe("resolveIncludes", () => {
     expect(expanded).toContain("{$site}");
   });
 
+  describe("default-value idiom (duplicate key)", () => {
+    // A template forwards a variable with a fallback default by writing
+    // `key={$key}|key=default`. Once the caller's value is substituted,
+    // the duplicate-key pair must resolve to the caller's value when
+    // present, or the default otherwise.
+
+    test("caller value wins over the default", () => {
+      const source = "[[include tmpl | foo=given]]";
+      // Template forwards foo to an inner include with a default.
+      const fetcher = (ref: { site: string | null; page: string }) => {
+        if (ref.page === "tmpl") return "[[include base foo={$foo}|foo=fallback]]";
+        if (ref.page === "base") return "<<{$foo}>>";
+        return null;
+      };
+      expect(resolveIncludes(source, fetcher)).toBe("<<given>>");
+    });
+
+    test("default applies when caller omits the variable", () => {
+      const source = "[[include tmpl]]";
+      const fetcher = (ref: { site: string | null; page: string }) => {
+        if (ref.page === "tmpl") return "[[include base foo={$foo}|foo=fallback]]";
+        if (ref.page === "base") return "<<{$foo}>>";
+        return null;
+      };
+      // {$foo} stays unresolved (placeholder), so the default `fallback` wins.
+      expect(resolveIncludes(source, fetcher)).toBe("<<fallback>>");
+    });
+
+    test("default applies when caller passes an empty value", () => {
+      const source = "[[include base foo=|foo=fallback]]";
+      const fetcher = () => "<<{$foo}>>";
+      expect(resolveIncludes(source, fetcher)).toBe("<<fallback>>");
+    });
+
+    test("first concrete value wins among several duplicates", () => {
+      const source = "[[include base foo=first|foo=second|foo=third]]";
+      const fetcher = () => "<<{$foo}>>";
+      expect(resolveIncludes(source, fetcher)).toBe("<<first>>");
+    });
+
+    test("multiple keys each resolve independently", () => {
+      const source = "[[include tmpl | a=A]]";
+      const fetcher = (ref: { site: string | null; page: string }) => {
+        if (ref.page === "tmpl") return "[[include base a={$a}|a=da|b={$b}|b=db]]";
+        if (ref.page === "base") return "<<{$a}|{$b}>>";
+        return null;
+      };
+      // a supplied -> A ; b omitted -> default db
+      expect(resolveIncludes(source, fetcher)).toBe("<<A|db>>");
+    });
+  });
+
   test("handles space-separated parameters in first segment", () => {
     const source = "[[include component:coltop show=+ 開く|hide=- 閉じる]]";
     let receivedPageRef: { site: string | null; page: string } | null = null;


### PR DESCRIPTION
## Summary

- Wikidot テンプレートでよく使われる「初期値代入イディオム」(`key={$key}|key=default`) が、wp 側の `parseIncludeDirective` の **last-wins** 実装によって常に default で上書きされ、呼び出し元の値が反映されない問題を修正。
- 仕様 (Wikidot 互換) に合わせ **first-concrete-wins** に変更: 同一キーの複数代入のうち、空文字でも `{$placeholder}` でもない **最初の concrete な値** が勝つ。

## Changes

- `packages/parser/src/parser/rules/block/module/include/resolve.ts`:
  - `parseIncludeDirective` の `variables[key] = value` ロジックを first-concrete-wins に変更。
  - 値が空文字 (`""`) または `{$...}` placeholder ならば「concrete でない」と判定。
  - 既に concrete 値がセットされていれば後続の代入は無視。concrete がまだなら placeholder/空でも仮置きしておき、後で concrete に置き換わる余地を残す。

## 背景

Wikidot テンプレート `[[include base key={$key}|key=default]]` は「呼び出し元が `key` を渡した時はその値、渡さなければ `default`」というイディオム。outer include が `{$key}` を実引数で置換した結果、内側 segment が以下のいずれかになる:

- `key=value | key=default` (呼び出し元が値を渡した) → `value` を採用したい
- `key= | key=default` (空文字で渡した) → `default` を採用したい
- `key={$key} | key=default` (呼び出し元が省略、placeholder 未解決) → `default` を採用したい

last-wins だと常に `default` になり、first-concrete-wins だと意図通りに動く。

## Test plan

- [x] 呼び出し元が値を渡した時に値が勝つ (`width=700px|width=300px` → `700px`)。
- [x] 呼び出し元が省略 (`{$width}` 未解決) で default が勝つ (`width={$width}|width=300px` → `300px`)。
- [x] 空文字明示時に default が勝つ (`width=|width=300px` → `300px`)。
- [x] 3 つ以上の重複指定で first-concrete を採用 (`width=first|width=second|width=third` → `first`)。
- [x] 複数キーの混在でも独立に動作。
- [x] lint / format / typecheck 通過。
- [x] 全体テスト通過。
