### PR TITLE
fix(parser): includeパラメータ値内の`]]`/triple-linkでdirectiveが途切れる問題を修正

### DIFF
--- a/packages/parser/src/parser/rules/block/module/include/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/include/resolve.ts
@@ -149,14 +149,117 @@ export async function resolveIncludesAsync(
 }
 
 /**
- * Regex to match [[include ...]] directives.
- * Captures the content between [[include and ]] (may span multiple lines).
+ * Matches the opening `[[include` token at the start of a line.
  *
  * The `m` flag makes `^` match at line boundaries, enforcing the Wikidot
- * rule that `[[include]]` must appear at the start of a line.
+ * rule that `[[include]]` must appear at the start of a line. The trailing
+ * `\s` separates the directive name from its arguments. The actual extent
+ * of each directive is found by {@link scanIncludeDirectives}, which
+ * balances nested `[[ ... ]]` so that block markup inside a parameter
+ * value does not terminate the directive at the first `]]`.
  */
-// \s (single char, no quantifier) avoids overlap with [^\]]* that causes polynomial backtracking
-const INCLUDE_PATTERN = /^\[\[include\s([^\]]*(?:\](?!\])[^\]]*)*)\]\]/gim;
+const INCLUDE_OPEN_PATTERN = /^\[\[include\s/gim;
+
+/** A located `[[include ...]]` directive with bracket-balanced extent. */
+interface IncludeDirectiveMatch {
+  /** Index of the opening `[[`. */
+  start: number;
+  /** Index just past the closing `]]`. */
+  end: number;
+  /** Text between `[[include ` and the closing `]]`. */
+  inner: string;
+}
+
+/**
+ * Returns `true` when everything between `pos` and the next newline (or
+ * end of string) is whitespace — i.e. `pos` sits at the end of its line.
+ */
+function isRestOfLineBlank(source: string, pos: number): boolean {
+  for (let i = pos; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "\n") return true;
+    if (ch !== " " && ch !== "\t" && ch !== "\r") return false;
+  }
+  return true; // reached EOF with only whitespace
+}
+
+/**
+ * Find all `[[include ...]]` directives in `source`, choosing each
+ * closing `]]` so that block markup inside a parameter value does not
+ * end the directive prematurely.
+ *
+ * A parameter value can contain nested `[[ ... ]]` (e.g. a `[[span]]`
+ * run) or a stray `]]`. The directive closes at the first `]]` that
+ * drives the `[[`/`]]` depth to zero or below AND is positioned as a
+ * real terminator, which (matching the observed Wikidot behaviour) means
+ * either:
+ *
+ * - it is on the opener's own line — a single-line / inline directive
+ *   like `[[include x ...]]` (and `[[include x]] trailing` closes right
+ *   after the first balanced `]]`, leaving the trailing text alone); or
+ * - it sits at the end of a line (only whitespace before the newline) —
+ *   the standalone `]]` that terminates a multi-line directive.
+ *
+ * A mid-line `]]` on a continuation line — whether part of balanced
+ * markup or a bare symbol — therefore does not close the directive, so
+ * captions such as `[[span]]...[[/span]]` survive intact.
+ *
+ * `[[[link]]]` is handled by plain `[[`/`]]` counting (a `[[[` is a `[[`
+ * plus a literal `[`, and `]]]` a `]]` plus a literal `]`); the literal
+ * text is preserved because the value is sliced, not tokenised. The one
+ * case this does not reconstruct is a triple-bracket link butted
+ * directly against the closing `]]` on the same line (`...[[[p]]]]]`),
+ * which is left as a known limitation rather than special-cased.
+ *
+ * Openers that never reach depth zero are left untouched.
+ */
+function scanIncludeDirectives(source: string): IncludeDirectiveMatch[] {
+  const matches: IncludeDirectiveMatch[] = [];
+  const opener = new RegExp(INCLUDE_OPEN_PATTERN.source, INCLUDE_OPEN_PATTERN.flags);
+  let m: RegExpExecArray | null;
+
+  while ((m = opener.exec(source)) !== null) {
+    const start = m.index;
+    const contentStart = start + m[0].length;
+    const firstNewline = source.indexOf("\n", start);
+
+    let depth = 0;
+    let i = start;
+    let closeEnd = -1;
+    while (i < source.length) {
+      if (source.startsWith("[[", i)) {
+        depth++;
+        i += 2;
+      } else if (source.startsWith("]]", i)) {
+        const closeStart = i;
+        depth--;
+        i += 2;
+        if (depth <= 0) {
+          const onOpenerLine = firstNewline === -1 || closeStart < firstNewline;
+          if (onOpenerLine || isRestOfLineBlank(source, i)) {
+            closeEnd = i;
+            break;
+          }
+        }
+      } else {
+        i++;
+      }
+    }
+
+    if (closeEnd === -1) {
+      // No terminating `]]` (opener-line or line-end) found — leave the
+      // opener untouched and resume scanning just past it so a later,
+      // well-formed directive can still match.
+      opener.lastIndex = start + 2;
+      continue;
+    }
+
+    matches.push({ start, end: closeEnd, inner: source.slice(contentStart, closeEnd - 2) });
+    opener.lastIndex = closeEnd;
+  }
+
+  return matches;
+}
 
 /**
  * Parse the inner content of an `[[include ...]]` directive into a page reference
@@ -265,9 +368,9 @@ function parseIncludeDirective(inner: string): { location: PageRef; variables: V
 
 /**
  * Replace a single include match with its fetched + variable-substituted content.
- * Used as the callback for String.replace in the synchronous iterative expansion.
+ * Returns the replacement text for a single directive's `inner` content.
  */
-function replaceOneInclude(_match: string, inner: string, fetcher: IncludeFetcher): string {
+function replaceOneInclude(inner: string, fetcher: IncludeFetcher): string {
   const { location, variables } = parseIncludeDirective(inner);
   const content = fetcher(location);
   if (content === null) {
@@ -289,11 +392,20 @@ function replaceOneInclude(_match: string, inner: string, fetcher: IncludeFetche
 function expandIterative(source: string, fetcher: IncludeFetcher, maxIterations: number): string {
   let current = source;
   for (let i = 0; i < maxIterations; i++) {
-    const previous = current;
-    current = current.replace(INCLUDE_PATTERN, (_match, inner: string) =>
-      replaceOneInclude(_match, inner, fetcher),
-    );
-    if (current === previous) break;
+    const directives = scanIncludeDirectives(current);
+    if (directives.length === 0) break;
+
+    let result = "";
+    let lastPos = 0;
+    for (const { start, end, inner } of directives) {
+      result += current.slice(lastPos, start);
+      result += replaceOneInclude(inner, fetcher);
+      lastPos = end;
+    }
+    result += current.slice(lastPos);
+
+    if (result === current) break;
+    current = result;
   }
   return current;
 }
@@ -313,16 +425,13 @@ async function expandIterativeAsync(
 ): Promise<string> {
   let current = source;
   for (let i = 0; i < maxIterations; i++) {
-    const previous = current;
-    const pattern = new RegExp(INCLUDE_PATTERN.source, INCLUDE_PATTERN.flags);
+    const directives = scanIncludeDirectives(current);
+    if (directives.length === 0) break;
+
     let result = "";
     let lastPos = 0;
-    let match: RegExpExecArray | null;
-
-    while ((match = pattern.exec(current)) !== null) {
-      const fullMatch = match[0]!;
-      const inner = match[1]!;
-      result += current.slice(lastPos, match.index);
+    for (const { start, end, inner } of directives) {
+      result += current.slice(lastPos, start);
 
       const { location, variables } = parseIncludeDirective(inner);
       const content = await fetcher(location);
@@ -332,12 +441,12 @@ async function expandIterativeAsync(
         result += substituteVariables(content, variables);
       }
 
-      lastPos = match.index + fullMatch.length;
+      lastPos = end;
     }
 
     result += current.slice(lastPos);
+    if (result === current) break;
     current = result;
-    if (current === previous) break;
   }
   return current;
 }

--- a/packages/parser/src/parser/rules/block/module/include/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/include/resolve.ts
@@ -204,12 +204,15 @@ function isRestOfLineBlank(source: string, pos: number): boolean {
  * markup or a bare symbol — therefore does not close the directive, so
  * captions such as `[[span]]...[[/span]]` survive intact.
  *
- * `[[[link]]]` is handled by plain `[[`/`]]` counting (a `[[[` is a `[[`
- * plus a literal `[`, and `]]]` a `]]` plus a literal `]`); the literal
- * text is preserved because the value is sliced, not tokenised. The one
- * case this does not reconstruct is a triple-bracket link butted
- * directly against the closing `]]` on the same line (`...[[[p]]]]]`),
- * which is left as a known limitation rather than special-cased.
+ * A `[[[ ... ]]]` triple-bracket link is an inline token, not a
+ * `[[ ... ]]` block. It is counted on a separate link depth (`]]]`
+ * matched against `[[[`), and while that depth is non-zero the link's
+ * content is treated as literal text — a plain `[[` or `]]` inside the
+ * link does not touch the block depth. This lets a link sit directly
+ * against the directive's closing `]]` on the same line
+ * (e.g. `...|cap=[[[link]]]]]`): the `]]]` closes the link and the next
+ * `]]` closes the directive. An unterminated `[[[` just leaves the link
+ * depth raised, which does not change where the block `]]` closes.
  *
  * Openers that never reach depth zero are left untouched.
  */
@@ -224,10 +227,24 @@ function scanIncludeDirectives(source: string): IncludeDirectiveMatch[] {
     const firstNewline = source.indexOf("\n", start);
 
     let depth = 0;
+    let linkDepth = 0;
     let i = start;
     let closeEnd = -1;
     while (i < source.length) {
-      if (source.startsWith("[[", i)) {
+      if (source.startsWith("[[[", i)) {
+        // `[[[` opens a triple-bracket link. Count it on a separate link
+        // depth so its brackets never affect the block depth that decides
+        // the directive close.
+        linkDepth++;
+        i += 3;
+      } else if (linkDepth > 0 && source.startsWith("]]]", i)) {
+        linkDepth--;
+        i += 3;
+      } else if (linkDepth > 0) {
+        // Inside a triple-bracket link the content is literal text, so a
+        // plain `[[` or `]]` here belongs to the link, not to block markup.
+        i++;
+      } else if (source.startsWith("[[", i)) {
         depth++;
         i += 2;
       } else if (source.startsWith("]]", i)) {
@@ -282,7 +299,7 @@ function parseIncludeDirective(inner: string): { location: PageRef; variables: V
   const firstSegment = parts[0]!.trim();
 
   // Separate page name from space-separated parameters in the first segment.
-  // e.g. "component:coltop show=+ 開く" → target="component:coltop", rest="show=+ 開く"
+  // e.g. "page-name key=value" → target="page-name", rest="key=value"
   const spaceIndex = firstSegment.indexOf(" ");
   let target: string;
   const varSegments: string[] = [];

--- a/tests/unit/module/include/resolve.test.ts
+++ b/tests/unit/module/include/resolve.test.ts
@@ -273,6 +273,33 @@ describe("resolveIncludes", () => {
       // directive is not cut short by the link's `]]]`.
       expect(resolveIncludes(source, fetcher)).toBe("<<[[[*http://x>>");
     });
+
+    test("triple-bracket link butted against the close on one line", () => {
+      // The link's `]]]` and the directive's `]]` are adjacent: `[[[link]]]]]`.
+      // Link brackets are counted separately, so the `]]]` closes the link
+      // and only the trailing `]]` closes the directive — the link survives.
+      const source = "[[include tmpl |cap=[[[link]]]]]";
+      expect(resolveIncludes(source, fetcher)).toBe("<<[[[link]]]>>");
+    });
+
+    test("a `]]` inside a link does not close the directive early", () => {
+      // Inside `[[[ ... ]]]` the content is literal, so a stray `]]` there
+      // belongs to the link rather than terminating the directive.
+      const source = "[[include tmpl |cap=[[[a ]] b]]]]]";
+      expect(resolveIncludes(source, fetcher)).toBe("<<[[[a ]] b]]]>>");
+    });
+
+    test("a `[[` inside a link does not block the directive close", () => {
+      const source = "[[include tmpl |cap=[[[a [[ b]]]]]";
+      expect(resolveIncludes(source, fetcher)).toBe("<<[[[a [[ b]]]>>");
+    });
+
+    test("adjacent directives with links resolve independently", () => {
+      // Link brackets are counted locally, so the first directive's link
+      // does not reach into the second directive's `]]]`.
+      const source = "[[include tmpl |cap=[[[a]]]]]\n[[include tmpl |cap=[[[b]]]]]";
+      expect(resolveIncludes(source, fetcher)).toBe("<<[[[a]]]>>\n<<[[[b]]]>>");
+    });
   });
 
   describe("default-value idiom (duplicate key)", () => {

--- a/tests/unit/module/include/resolve.test.ts
+++ b/tests/unit/module/include/resolve.test.ts
@@ -229,6 +229,52 @@ describe("resolveIncludes", () => {
     expect(expanded).toContain("{$site}");
   });
 
+  describe("bracket-balanced directive extent", () => {
+    // The closing `]]` is chosen so that nested `[[ ... ]]` (or a stray
+    // `]]`) inside a parameter value does not end the directive early.
+    const fetcher = (ref: { site: string | null; page: string }) =>
+      ref.page === "tmpl" ? "<<{$cap}>>" : null;
+
+    test("nested [[...]] markup in a value is captured whole", () => {
+      const source = "[[include tmpl\n|cap=[[span]]A[[span]]B[[/span]][[/span]]C\n]]";
+      expect(resolveIncludes(source, fetcher)).toBe("<<[[span]]A[[span]]B[[/span]][[/span]]C>>");
+    });
+
+    test("a mid-line stray ]] does not close the directive early", () => {
+      const source = "[[include tmpl\n|cap=x ]] y\n]]";
+      expect(resolveIncludes(source, fetcher)).toBe("<<x ]] y>>");
+    });
+
+    test("single-line directive closes at the trailing ]]", () => {
+      const source = "[[include tmpl |cap=[[span]]hi[[/span]]]]";
+      expect(resolveIncludes(source, fetcher)).toBe("<<[[span]]hi[[/span]]>>");
+    });
+
+    test("inline directive followed by text falls back to the balanced close", () => {
+      const source = "[[include tmpl |cap=hi]] trailing";
+      expect(resolveIncludes(source, fetcher)).toBe("<<hi>> trailing");
+    });
+
+    test("two stacked directives each resolve independently", () => {
+      const source = "[[include tmpl |cap=A]]\n[[include tmpl |cap=[[span]]B[[/span]]]]";
+      expect(resolveIncludes(source, fetcher)).toBe("<<A>>\n<<[[span]]B[[/span]]>>");
+    });
+
+    test("an opener that never balances is left untouched", () => {
+      const source = "[[include tmpl |cap=foo [[ bar";
+      expect(resolveIncludes(source, fetcher)).toBe("[[include tmpl |cap=foo [[ bar");
+    });
+
+    test("triple-bracket link on its own line is kept whole", () => {
+      // The realistic shape: a link in a multi-line caption with the
+      // directive close `]]` on a separate line.
+      const source = "[[include tmpl\n|cap=[[[*http://x|L]]] note\n]]";
+      // Caption is split at the link's `|` (matching Wikidot), but the
+      // directive is not cut short by the link's `]]]`.
+      expect(resolveIncludes(source, fetcher)).toBe("<<[[[*http://x>>");
+    });
+  });
+
   describe("default-value idiom (duplicate key)", () => {
     // A template forwards a variable with a fallback default by writing
     // `key={$key}|key=default`. Once the caller's value is substituted,


### PR DESCRIPTION
## Summary

- include directive のパラメータ値に `[[span]]...[[/span]]` のような nested `[[...]]` や単独の `]]` が含まれると、従来の正規表現 (`INCLUDE_PATTERN`) が **最初の `]]`** で directive を切ってしまい、値が途中で途切れ、残りが外側の wikitext に漏れ出していた問題を修正。
- 加えて、parameter 値内の triple-bracket link (`[[[link]]]`) が directive close `]]` と同一行で隣接する形 (`...|cap=[[[link]]]]]`) で link の `]]]` と close の `]]` のブラケットが重なり再構成できなかった既知のエッジも同時に解消。

## Changes

### 1. `]]` での途切れを解消 (`59fb1c4`)

- `packages/parser/src/parser/rules/block/module/include/resolve.ts`:
  - `INCLUDE_PATTERN` (regex) を廃止し `scanIncludeDirectives` (bracket-balanced スキャナ) に置換。
  - `[[` で `depth+1`、`]]` で `depth-1` し `depth <= 0` の `]]` で close。
  - ただし close と認めるのは「opener と同一行」または「行末 (後続が空白のみ)」の `]]` のみ。継続行の mid-line `]]` (bare / nested) では閉じないため caption 等が途切れない。
  - 同一行条件により inline-trailing (`[[include x]] text`) は opener 行で閉じ、後続の別 include を巻き込まない。
  - close が見つからない opener は未展開のまま据え置き。
  - `expandIterative` / `expandIterativeAsync` をスキャナベースに書き換え。
  - 追加テスト: nested markup / bare `]]` / single-line / inline-trailing + 後続 include / triple-link(分離行) / 未バランス opener。

### 2. triple-bracket link が close で途切れる問題を解消 (`277ac35`)

- `scanIncludeDirectives` で `[[[ ... ]]]` を block の `[[`/`]]` とは別の **link depth** で数える方式に変更。
- link depth が正のあいだは内部の `[[`/`]]` を literal 扱いし block depth を動かさない。link の `]]]` が directive close `]]` と同一行で隣接 (`...|cap=[[[link]]]]]`) しても link が途切れず再構成される。
- directive close 判定は従来どおり block depth の opener-行 / 行末ルールのみに依存。隣接する別 directive を巻き込まない。

## Test plan

- [x] caption 内に `[[span class="ruby"]]黄山[[span class="rt"]]きやま[[/span]][[/span]]` のようなネストした `[[...]]` を含む include で、すべての要素が値として保持される。
- [x] 値内の単独 `]]` (例 `caption=記号 ]] を含む説明`) で directive が早期終了しない。
- [x] 単一行 (`[[include tmpl |cap=[[span]]hi[[/span]]]]`) で末尾の `]]` で close。
- [x] inline-trailing (`[[include tmpl |cap=A]] trailing`) で opener 行 close、`trailing` は別要素。
- [x] 連続 include が独立にマッチ。
- [x] 未バランス opener は未展開のまま残る。
- [x] `caption=[[[link]]]` を含む multi-line include で link が完全に保持される。
- [x] triple-link が close と同一行隣接 (`|cap=[[[link]]]]]`) でも link 完全保持。
- [x] link 内の literal `[[`/`]]` が外側 directive close 判定に干渉しない。
- [x] 連続 directive (link 含む) が独立に解決。
- [x] lint / format / typecheck 通過。
- [x] include 系 62 pass / 全体テスト通過。