### PR TITLE
feat(parser): [[iftags]]のtext-level preprocess pass追加

### DIFF
--- a/examples/wdmock-cf/apps/main/src/services/pipeline.ts
+++ b/examples/wdmock-cf/apps/main/src/services/pipeline.ts
@@ -3,7 +3,13 @@
  *
  * Handles source parsing, module resolution, and HTML rendering.
  */
-import { parse, extractDataRequirements, resolveModules, resolveIncludes } from "@wdprlib/parser";
+import {
+  parse,
+  extractDataRequirements,
+  resolveModules,
+  resolveIncludes,
+  preprocessIftags,
+} from "@wdprlib/parser";
 import type {
   NormalizedListPagesQuery,
   ListPagesExternalData,
@@ -47,15 +53,21 @@ export async function renderPage(
   const expanded = resolveIncludes(source, (pageRef: PageRef) => {
     return pageSourceMap.get(pageRef.page) ?? null;
   });
-  const { ast: resolved, diagnostics: _diagnostics = [] } = parse(expanded);
 
-  const { requirements, compiledListPagesTemplates } = extractDataRequirements(resolved);
-
+  // Fetch the page's tags before parsing so source-level [[iftags]]
+  // (e.g. inside a [[div_]] opener attribute, which the AST resolver
+  // cannot reach because it would be eaten as garbage by the block
+  // tokenizer) can be expanded against them.
   const pageTags = await getTagsByFullname(
     db,
     parseFullname(pageName).category,
     parseFullname(pageName).name,
   );
+
+  const preprocessed = preprocessIftags(expanded, pageTags);
+  const { ast: resolved, diagnostics: _diagnostics = [] } = parse(preprocessed);
+
+  const { requirements, compiledListPagesTemplates } = extractDataRequirements(resolved);
 
   const modulesResolved = await resolveModules(
     resolved,

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -145,6 +145,8 @@ export {
   // Include resolution
   resolveIncludes,
   resolveIncludesAsync,
+  // IfTags source-level preprocessing (run between include expansion and parse)
+  preprocessIftags,
   // Query normalization (for advanced use cases)
   normalizeQuery,
   parseTags,

--- a/packages/parser/src/parser/rules/block/module/iftags/index.ts
+++ b/packages/parser/src/parser/rules/block/module/iftags/index.ts
@@ -21,3 +21,6 @@ export { parseTagCondition, evaluateTagCondition } from "./condition";
 // Resolution
 export type { IfTagsData, IfTagsResolveResult } from "./resolve";
 export { isIfTagsElement, resolveIfTags } from "./resolve";
+
+// Source-level preprocessing (must run after include expansion, before parse)
+export { preprocessIftags } from "./preprocess";

--- a/packages/parser/src/parser/rules/block/module/iftags/preprocess.ts
+++ b/packages/parser/src/parser/rules/block/module/iftags/preprocess.ts
@@ -1,0 +1,288 @@
+/**
+ *
+ * Text-level expansion of `[[iftags]]` blocks before parsing.
+ *
+ * Unlike the AST-level {@link resolveIfTags} resolver, which evaluates
+ * `if-tags` nodes after parsing, this pass operates directly on the
+ * raw wikitext source. The difference matters for templates that embed
+ * an `[[iftags]]` block inside another construct's attribute string,
+ * for example:
+ *
+ * ```wikitext
+ * [[div_ class="x" [[iftags +foo]]style="display:none;"[[/iftags]]]]
+ * ```
+ *
+ * The block-level tokenizer cannot recover a well-formed opener from
+ * that input — the inner `[[iftags ...]]X[[/iftags]]` has to collapse
+ * to either `X` or the empty string *before* the parser sees the outer
+ * tag, so the attribute string becomes plain text again. The AST-level
+ * `[[iftags]]` block rule still exists and handles cases where the
+ * preprocess pass is skipped (`pageTags === null`).
+ *
+ * Pipeline order:
+ *
+ * ```
+ * getPageTags → resolveIncludes → preprocessIftags(source, pageTags) → parse → resolveModules
+ * ```
+ *
+ * Running this after include expansion is intentional: an included
+ * page may itself embed `[[iftags]]`, and the condition is evaluated
+ * against the *including* page's tags, not the included page's.
+ *
+ * @module
+ */
+
+import { parseTagCondition, evaluateTagCondition } from "./condition";
+
+/**
+ * Base sentinel characters used to wrap raw-region placeholders during
+ * the iftags scan. Both code points fall inside the Unicode Private
+ * Use Area (U+E000–U+F8FF) and so they should not appear in legitimate
+ * wikitext, but in case the input contains them anyway, the sentinels
+ * are extended with extra copies until the resulting marker string is
+ * provably absent from the source — see {@link makeUniqueSentinels}.
+ */
+const BASE_PLACEHOLDER_OPEN = "";
+const BASE_PLACEHOLDER_CLOSE = "";
+
+/**
+ * Matches one `[[iftags ...]]X[[/iftags]]` where `X` contains no further
+ * `[[iftags]]` opener or closer. Used for innermost-first reduction.
+ *
+ * - `g` (global): a single `replace` pass rewrites every innermost block,
+ *   so sibling blocks collapse together and the reduction loop runs once
+ *   per nesting level rather than once per block.
+ * - `i` (case-insensitive): Wikidot block names are case-insensitive
+ * - `s` (dot matches newline): bodies can span multiple lines
+ * - `[^\]]*` for the condition: tag-condition tokens (`+tag`, `-tag`,
+ *   bare names) never contain `]`, and stopping at the first `]` keeps
+ *   the regex linear in body length even on degenerate input.
+ */
+const INNERMOST_IFTAGS_PATTERN =
+  /\[\[\s*iftags\b([^\]]*)\]\]((?:(?!\[\[\s*iftags\b|\[\[\/\s*iftags\s*\]\]).)*)\[\[\/\s*iftags\s*\]\]/gis;
+
+/**
+ * Matches `[[code ...]]` or `[[html ...]]` openers (case-insensitive).
+ * The captured group is the block name so the matching closing tag can
+ * be located. The sticky (`y`) flag lets the masker test for an opener
+ * at a given index without slicing the source on every `[[`.
+ */
+const RAW_BLOCK_OPEN_PATTERN = /\[\[\s*(code|html)\b[^\]]*\]\]/iy;
+
+/**
+ * Expand `[[iftags ...]]X[[/iftags]]` directives in `source` against the
+ * current page's tags.
+ *
+ * Returns `source` unchanged when `pageTags` is `null`, which signals
+ * that the caller could not resolve tag membership (e.g. rendering a
+ * draft preview without a real page). In that case the AST-level
+ * resolver remains responsible for evaluation later.
+ *
+ * Behaviour:
+ * - Raw regions (`[[code]]`, `[[html]]`, `@@...@@`, `@<...>@`) are
+ *   protected: literal `[[iftags]]` tokens inside them are not expanded.
+ * - Nested `[[iftags]]` are processed innermost-first, so an outer
+ *   block can re-process the now-flattened inner body uniformly.
+ *
+ * @param source   Raw wikitext (typically after include expansion).
+ * @param pageTags Tags of the page being rendered, or `null` to skip.
+ * @returns Source with matching iftags replaced by their bodies and
+ *          unmatched iftags removed entirely.
+ */
+export function preprocessIftags(source: string, pageTags: string[] | null): string {
+  if (pageTags === null) return source;
+  if (!source.includes("[[")) return source; // fast path
+
+  const sentinels = makeUniqueSentinels(source);
+  const { masked, placeholders } = maskRawRegions(source, sentinels);
+  const reduced = reduceIftags(masked, pageTags);
+  return restorePlaceholders(reduced, placeholders, sentinels);
+}
+
+/**
+ * Choose sentinel strings that are guaranteed not to appear in the
+ * supplied source. The placeholders we splice into the masked source
+ * have the form `<open><digits><close>`, so if a user-authored region
+ * happened to contain that exact sequence the restore pass would
+ * either swap in the wrong content or silently delete the match.
+ *
+ * Starting from the base PUA sentinels, we repeatedly append a copy of
+ * each character until neither appears anywhere in `source`. The loop
+ * is bounded by the source length, which is reached only in the
+ * degenerate case where the input consists entirely of the base
+ * sentinel character.
+ */
+function makeUniqueSentinels(source: string): { open: string; close: string } {
+  let open = BASE_PLACEHOLDER_OPEN;
+  let close = BASE_PLACEHOLDER_CLOSE;
+  while (source.includes(open) || source.includes(close)) {
+    open += BASE_PLACEHOLDER_OPEN;
+    close += BASE_PLACEHOLDER_CLOSE;
+  }
+  return { open, close };
+}
+
+/**
+ * Replace `[[iftags ...]]X[[/iftags]]` blocks innermost-first until no
+ * iftags pair remains. The pattern is global, so each pass rewrites all
+ * innermost blocks at once and thus eliminates one nesting level;
+ * matched blocks become their body (if the condition holds) or the empty
+ * string (otherwise).
+ *
+ * The loop terminates because every pass that changes the string removes
+ * at least one nesting level. If the regex fails to match (no more
+ * pairs, or unbalanced leftovers), the loop exits with the partially
+ * reduced source.
+ */
+function reduceIftags(source: string, pageTags: string[]): string {
+  let current = source;
+  // Worst-case bound: one pass eliminates at least one nesting level, and
+  // nesting depth is at most `source.length`. The explicit cap stops a
+  // runaway regex (e.g. pathological zero-width match) from looping forever.
+  const maxIterations = source.length + 1;
+  for (let i = 0; i < maxIterations; i++) {
+    const next = current.replace(INNERMOST_IFTAGS_PATTERN, (_, cond: string, body: string) => {
+      const condition = parseTagCondition(cond);
+      return evaluateTagCondition(condition, pageTags) ? body : "";
+    });
+    if (next === current) return current;
+    current = next;
+  }
+  return current;
+}
+
+/**
+ * Walk `source` and replace each raw region with a placeholder token
+ * that downstream regex passes will not match against. The original
+ * substrings are kept in `placeholders` so `restorePlaceholders` can
+ * splice them back at the end.
+ *
+ * Raw regions handled:
+ * - `[[code ...]]...[[/code]]` — consumes to EOF when the closing tag
+ *   is missing, mirroring the block parser's behaviour for unclosed
+ *   code blocks (it still collects content as raw and warns).
+ * - `[[html ...]]...[[/html]]` — only masked when the closing tag is
+ *   present. The block parser drops an unclosed `[[html]]` to literal
+ *   text after warning, so preprocess must leave the body alone here
+ *   too; otherwise an `[[iftags]]` further down the source would be
+ *   incorrectly hidden behind the mask.
+ * - `@<...>@` (single-line balanced raw — `>@` must be on the same line
+ *   as the opening `@<`, mirroring the inline raw rule).
+ * - `@@...@@` (single-line inline raw — must not span newlines).
+ *
+ * Genuinely unclosed `@@` / `@<` (no closing on the same line) are
+ * left in place; the parser treats them as literal text anyway.
+ *
+ * Comments (`[!-- ... --]`) are deliberately NOT masked here. Wikidot's
+ * legacy Text_Wiki runs the Iftags rule *before* the Comment rule (see
+ * `lib/Text_Wiki/Text/Wiki.php`: Iftags at index 11, Comment at index 12),
+ * so an `[[iftags]]` inside a comment is expanded first and then the
+ * naive `[!--(.*?)--]` rule discards what's left. Masking comments here
+ * would invert that order and produce different output.
+ */
+function maskRawRegions(
+  source: string,
+  sentinels: { open: string; close: string },
+): { masked: string; placeholders: string[] } {
+  const placeholders: string[] = [];
+  let masked = "";
+  let i = 0;
+
+  while (i < source.length) {
+    // [[code ...]] / [[html ...]]
+    if (source[i] === "[" && source[i + 1] === "[") {
+      RAW_BLOCK_OPEN_PATTERN.lastIndex = i;
+      const openMatch = RAW_BLOCK_OPEN_PATTERN.exec(source);
+      if (openMatch) {
+        const name = openMatch[1]!.toLowerCase();
+        const openLen = openMatch[0].length;
+        // Find matching `[[/<name>]]` (case-insensitive, allows whitespace before name).
+        // The `g` flag plus an explicit `lastIndex` searches forward from the
+        // opener without slicing the source.
+        const closePattern = new RegExp(`\\[\\[\\/\\s*${name}\\s*\\]\\]`, "ig");
+        closePattern.lastIndex = i + openLen;
+        const closeMatch = closePattern.exec(source);
+        if (closeMatch) {
+          const regionEnd = closeMatch.index + closeMatch[0].length;
+          masked += pushPlaceholder(placeholders, source.slice(i, regionEnd), sentinels);
+          i = regionEnd;
+          continue;
+        }
+        // Unclosed: only `[[code]]` falls back to "consume to EOF" in
+        // the parser; `[[html]]` is dropped to literal text. Mirror
+        // that here so an unclosed `[[html]]` does not hide subsequent
+        // `[[iftags]]` from preprocess.
+        if (name === "code") {
+          masked += pushPlaceholder(placeholders, source.slice(i), sentinels);
+          i = source.length;
+          continue;
+        }
+      }
+    }
+
+    // @<...>@ balanced raw — closing must appear before the next newline
+    if (source[i] === "@" && source[i + 1] === "<") {
+      const close = source.indexOf(">@", i + 2);
+      const newline = source.indexOf("\n", i + 2);
+      if (close !== -1 && (newline === -1 || close < newline)) {
+        const regionEnd = close + 2;
+        masked += pushPlaceholder(placeholders, source.slice(i, regionEnd), sentinels);
+        i = regionEnd;
+        continue;
+      }
+    }
+
+    // @@...@@ inline raw (does not cross newlines)
+    if (source[i] === "@" && source[i + 1] === "@") {
+      const close = source.indexOf("@@", i + 2);
+      const newline = source.indexOf("\n", i + 2);
+      if (close !== -1 && (newline === -1 || close < newline)) {
+        const regionEnd = close + 2;
+        masked += pushPlaceholder(placeholders, source.slice(i, regionEnd), sentinels);
+        i = regionEnd;
+        continue;
+      }
+    }
+
+    masked += source[i];
+    i++;
+  }
+
+  return { masked, placeholders };
+}
+
+/** Append `text` to `placeholders` and return its sentinel-wrapped index. */
+function pushPlaceholder(
+  placeholders: string[],
+  text: string,
+  sentinels: { open: string; close: string },
+): string {
+  const idx = placeholders.length;
+  placeholders.push(text);
+  return `${sentinels.open}${idx}${sentinels.close}`;
+}
+
+/**
+ * Escape a string for safe inclusion in a `RegExp` constructor.
+ *
+ * The sentinels are usually single Private Use Area characters, which
+ * are already regex-safe, but the unique-sentinel fallback in
+ * {@link makeUniqueSentinels} may extend them — escape defensively so
+ * the function stays correct for any sentinel choice.
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Inverse of {@link pushPlaceholder} across the entire reduced string. */
+function restorePlaceholders(
+  source: string,
+  placeholders: string[],
+  sentinels: { open: string; close: string },
+): string {
+  const pattern = new RegExp(
+    `${escapeRegex(sentinels.open)}(\\d+)${escapeRegex(sentinels.close)}`,
+    "g",
+  );
+  return source.replace(pattern, (_, idx: string) => placeholders[Number(idx)] ?? "");
+}

--- a/packages/parser/src/parser/rules/block/module/index.ts
+++ b/packages/parser/src/parser/rules/block/module/index.ts
@@ -85,7 +85,13 @@ export {
 
 // IfTags module
 export type { TagCondition, IfTagsResolver, IfTagsData, IfTagsResolveResult } from "./iftags";
-export { parseTagCondition, evaluateTagCondition, isIfTagsElement, resolveIfTags } from "./iftags";
+export {
+  parseTagCondition,
+  evaluateTagCondition,
+  isIfTagsElement,
+  resolveIfTags,
+  preprocessIftags,
+} from "./iftags";
 
 // Include module
 export type { IncludeFetcher, AsyncIncludeFetcher, ResolveIncludesOptions } from "./include";

--- a/tests/unit/module/iftags/preprocess.test.ts
+++ b/tests/unit/module/iftags/preprocess.test.ts
@@ -1,0 +1,206 @@
+import { describe, test, expect } from "bun:test";
+import { preprocessIftags } from "../../../../packages/parser/src/parser/rules/block/module/iftags";
+
+describe("preprocessIftags", () => {
+  describe("pass-through", () => {
+    test("returns source unchanged when pageTags is null", () => {
+      const src = "before [[iftags +foo]]inside[[/iftags]] after";
+      expect(preprocessIftags(src, null)).toBe(src);
+    });
+
+    test("returns source unchanged when no iftags present", () => {
+      expect(preprocessIftags("plain text", ["foo"])).toBe("plain text");
+    });
+
+    test("fast-path when source contains no [[ at all", () => {
+      expect(preprocessIftags("no brackets here", ["foo"])).toBe("no brackets here");
+    });
+  });
+
+  describe("flat substitution", () => {
+    test("keeps body when condition matches required tag", () => {
+      const src = "before [[iftags +foo]]inside[[/iftags]] after";
+      expect(preprocessIftags(src, ["foo"])).toBe("before inside after");
+    });
+
+    test("removes body when required tag missing", () => {
+      const src = "before [[iftags +foo]]inside[[/iftags]] after";
+      expect(preprocessIftags(src, [])).toBe("before  after");
+    });
+
+    test("removes body when forbidden tag present", () => {
+      const src = "[[iftags -admin]]content[[/iftags]]";
+      expect(preprocessIftags(src, ["admin"])).toBe("");
+    });
+
+    test("keeps body when forbidden tag absent", () => {
+      const src = "[[iftags -admin]]content[[/iftags]]";
+      expect(preprocessIftags(src, ["user"])).toBe("content");
+    });
+
+    test("processes multiple sibling iftags", () => {
+      const src = "[[iftags +a]]A[[/iftags]] [[iftags +b]]B[[/iftags]]";
+      expect(preprocessIftags(src, ["a"])).toBe("A ");
+      expect(preprocessIftags(src, ["b"])).toBe(" B");
+      expect(preprocessIftags(src, ["a", "b"])).toBe("A B");
+    });
+  });
+
+  describe("nested iftags", () => {
+    test("matching outer and inner keep both bodies", () => {
+      const src = "[[iftags +o]]X [[iftags +i]]Y[[/iftags]] Z[[/iftags]]";
+      expect(preprocessIftags(src, ["o", "i"])).toBe("X Y Z");
+    });
+
+    test("matching outer with non-matching inner strips inner only", () => {
+      const src = "[[iftags +o]]X [[iftags +i]]Y[[/iftags]] Z[[/iftags]]";
+      expect(preprocessIftags(src, ["o"])).toBe("X  Z");
+    });
+
+    test("non-matching outer removes whole tree including inner", () => {
+      const src = "[[iftags +o]]X [[iftags +i]]Y[[/iftags]] Z[[/iftags]]";
+      expect(preprocessIftags(src, ["i"])).toBe("");
+    });
+
+    test("triple-nested", () => {
+      const src = "[[iftags +a]]A[[iftags +b]]B[[iftags +c]]C[[/iftags]][[/iftags]][[/iftags]]";
+      expect(preprocessIftags(src, ["a", "b", "c"])).toBe("ABC");
+      expect(preprocessIftags(src, ["a", "b"])).toBe("AB");
+      expect(preprocessIftags(src, ["a"])).toBe("A");
+      expect(preprocessIftags(src, [])).toBe("");
+    });
+  });
+
+  describe("raw region protection", () => {
+    test("does not touch [[iftags]] inside [[code]]", () => {
+      const src = "[[code]]\n[[iftags +foo]]nope[[/iftags]]\n[[/code]]";
+      expect(preprocessIftags(src, ["foo"])).toBe(src);
+    });
+
+    test("does not touch [[iftags]] inside [[html]]", () => {
+      const src = "[[html]]\n[[iftags +foo]]nope[[/iftags]]\n[[/html]]";
+      expect(preprocessIftags(src, ["foo"])).toBe(src);
+    });
+
+    test("does not touch [[iftags]] inside @@...@@", () => {
+      const src = "@@[[iftags +foo]]nope[[/iftags]]@@";
+      expect(preprocessIftags(src, ["foo"])).toBe(src);
+    });
+
+    test("does not touch [[iftags]] inside @<...>@", () => {
+      const src = "@<[[iftags +foo]]nope[[/iftags]]>@";
+      expect(preprocessIftags(src, ["foo"])).toBe(src);
+    });
+
+    test("@@..@@ does not cross newline (so multi-line iftags inside is processed)", () => {
+      // The @@ at line 1 has no closing @@ on the same line, so it is
+      // NOT a raw region. The [[iftags]] is therefore processed.
+      const src = "@@\n[[iftags +foo]]X[[/iftags]]\n@@";
+      const out = preprocessIftags(src, ["foo"]);
+      expect(out).toBe("@@\nX\n@@");
+    });
+
+    test("preserves @@ raw block when iftags body contains it", () => {
+      const src = "[[iftags +foo]] @@raw@@ inside [[/iftags]]";
+      expect(preprocessIftags(src, ["foo"])).toBe(" @@raw@@ inside ");
+    });
+  });
+
+  describe("iftags embedded inside a block opener's attribute string", () => {
+    const template =
+      `[[div_ class="x" [[iftags +foo]]style="display:none;"[[/iftags]]]]\n` + `content\n[[/div]]`;
+
+    test("matching tag expands to attribute", () => {
+      expect(preprocessIftags(template, ["foo"])).toBe(
+        `[[div_ class="x" style="display:none;"]]\ncontent\n[[/div]]`,
+      );
+    });
+
+    test("non-matching tag expands to empty", () => {
+      expect(preprocessIftags(template, [])).toBe(`[[div_ class="x" ]]\ncontent\n[[/div]]`);
+    });
+  });
+
+  describe("raw region edge cases", () => {
+    test("unclosed [[code]] consumes to EOF (literal iftags inside stays literal)", () => {
+      // Block parser falls through to "code until EOF" with a warning, so
+      // preprocess must mirror that — otherwise an iftags inside the
+      // unclosed code would be expanded while the parser still treats
+      // it as raw content.
+      const src = "[[code]]\n[[iftags +foo]]nope[[/iftags]]\n(no close)";
+      expect(preprocessIftags(src, ["foo"])).toBe(src);
+    });
+
+    test("unclosed [[html]] does NOT mask trailing iftags (parser drops it to text)", () => {
+      // The block parser fails on unclosed `[[html]]` and falls back to
+      // literal text, so anything after it is normal wikitext that
+      // preprocess must still see and expand.
+      const src = "[[html]]\nhtml body without close\n[[iftags +foo]]X[[/iftags]]";
+      const out = preprocessIftags(src, ["foo"]);
+      expect(out).toContain("X");
+      expect(out).not.toContain("[[iftags");
+    });
+
+    test("@<...>@ does NOT span newlines (Wikidot raw rule)", () => {
+      // The parser only treats `@<...>@` as raw when `>@` is on the same
+      // line as `@<`. If the closing marker is on a different line, the
+      // characters become literal text and any [[iftags]] in between is
+      // ordinary content — so preprocess must still expand it.
+      const src = "@<\n[[iftags +foo]]X[[/iftags]]\n>@";
+      const out = preprocessIftags(src, ["foo"]);
+      expect(out).toContain("X");
+      expect(out).not.toContain("[[iftags");
+    });
+
+    test("source containing the placeholder sentinel survives roundtrip", () => {
+      // The placeholder uses Private Use Area characters that should not
+      // appear in legitimate wikitext, but if they do (pasted content,
+      // hostile input), the unique-sentinel fallback must keep restore
+      // unambiguous.
+      const opener = "";
+      const closer = "";
+      const src = `before ${opener}0${closer} [[iftags +foo]]X[[/iftags]] after`;
+      expect(preprocessIftags(src, ["foo"])).toBe(`before ${opener}0${closer} X after`);
+    });
+  });
+
+  describe("Wikidot rule order: iftags runs before comment", () => {
+    test("an [[iftags]] inside a [!-- --] is expanded by this pass", () => {
+      // Wikidot's Text_Wiki runs the Iftags rule (index 11) before the
+      // Comment rule (index 12), so the iftags is evaluated first and the
+      // (now-flattened) text is left for the parser's comment rule to
+      // strip. preprocess must mirror that order — masking comments here
+      // would invert it.
+      const src = "a[!-- [[iftags +foo]]X[[/iftags]] --]b";
+      expect(preprocessIftags(src, ["foo"])).toBe("a[!-- X --]b");
+      expect(preprocessIftags(src, [])).toBe("a[!--  --]b");
+    });
+  });
+
+  describe("edge cases", () => {
+    test("unclosed [[iftags]] is left intact", () => {
+      const src = "before [[iftags +foo]]inside without close";
+      expect(preprocessIftags(src, ["foo"])).toBe(src);
+    });
+
+    test("orphan [[/iftags]] is left intact", () => {
+      const src = "before [[/iftags]] after";
+      expect(preprocessIftags(src, ["foo"])).toBe(src);
+    });
+
+    test("empty condition (super-comment-out) removes body", () => {
+      const src = "[[iftags]]hidden always[[/iftags]] visible";
+      expect(preprocessIftags(src, ["any"])).toBe(" visible");
+    });
+
+    test("case-insensitive block name", () => {
+      const src = "[[IFTAGS +foo]]X[[/IFTAGS]]";
+      expect(preprocessIftags(src, ["foo"])).toBe("X");
+    });
+
+    test("whitespace inside [[ iftags ...]] is tolerated", () => {
+      const src = "[[ iftags +foo ]]X[[/ iftags ]]";
+      expect(preprocessIftags(src, ["foo"])).toBe("X");
+    });
+  });
+});

--- a/tests/unit/parser/resolve/preprocess-iftags-integration.test.ts
+++ b/tests/unit/parser/resolve/preprocess-iftags-integration.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { parse, preprocessIftags } from "@wdprlib/parser";
+import { renderToHtml } from "@wdprlib/render";
+
+/**
+ * End-to-end coverage for the source-level `[[iftags]]` preprocessor.
+ *
+ * The point of `preprocessIftags` is to expand iftags BEFORE block-level
+ * parsing, so it has to combine with `parse` + `renderToHtml` to handle
+ * cases the AST-level resolver cannot — most notably an `[[iftags]]`
+ * embedded inside another block's attribute string. Once preprocess has
+ * collapsed the iftags, the resulting source is well-formed wikitext
+ * the parser can lex normally.
+ */
+describe("preprocessIftags + parse + render integration", () => {
+  function pipeline(source: string, tags: string[] | null): string {
+    const preprocessed = preprocessIftags(source, tags);
+    const { ast } = parse(preprocessed);
+    return renderToHtml(ast);
+  }
+
+  it("expands an iftags embedded in a block opener attribute (matching tag)", () => {
+    const src =
+      `[[div_ class="x" [[iftags +foo]]style="display:none;"[[/iftags]]]]\n` +
+      `inner\n` +
+      `[[/div]]`;
+    const html = pipeline(src, ["foo"]);
+    expect(html).toContain(`class="x"`);
+    expect(html).toContain(`style="display:none;"`);
+    expect(html).toContain("inner");
+  });
+
+  it("collapses an iftags embedded in a block opener attribute (non-matching tag)", () => {
+    const src =
+      `[[div_ class="x" [[iftags +foo]]style="display:none;"[[/iftags]]]]\n` +
+      `inner\n` +
+      `[[/div]]`;
+    const html = pipeline(src, []);
+    expect(html).toContain(`class="x"`);
+    expect(html).not.toContain("display:none");
+    expect(html).toContain("inner");
+  });
+
+  it("preprocessing a body that contains a nested iftags works end-to-end", () => {
+    const src = `[[div_]]\n` + `[[iftags +a]]A[[iftags +b]]B[[/iftags]][[/iftags]]\n` + `[[/div]]`;
+    const html = pipeline(src, ["a", "b"]);
+    expect(html).toContain("AB");
+  });
+
+  it("leaves [[iftags]] inside [[code]] alone (not preprocessed, not rendered as block)", () => {
+    const src = `[[code]]\n[[iftags +foo]]X[[/iftags]]\n[[/code]]`;
+    const html = pipeline(src, ["foo"]);
+    // The literal iftags text remains inside the code block output.
+    expect(html).toContain("[[iftags +foo]]X[[/iftags]]");
+  });
+
+  it("falls back to AST-level handling when pageTags is null", () => {
+    // null pageTags → preprocess is a no-op. The AST-level [[iftags]]
+    // block rule still parses the construct (and resolveModules would
+    // evaluate it later). At this layer (no resolveModules call) the
+    // if-tags element ends up in the AST with its body preserved.
+    const src = `[[iftags +foo]]body[[/iftags]]`;
+    const preprocessed = preprocessIftags(src, null);
+    expect(preprocessed).toBe(src);
+    const { ast } = parse(preprocessed);
+    expect(JSON.stringify(ast)).toContain("if-tags");
+  });
+});


### PR DESCRIPTION
## Summary

- `[[iftags ...]]X[[/iftags]]` を pageTags 評価で text-level に展開する pass を追加。
- AST レベルの `resolveIfTags` では到達できないブロック opener 属性内の iftags (例 `[[div_ class="x" [[iftags +foo]]style="display:none;"[[/iftags]]]]`) を扱えるようにする。
- Wikidot legacy (`lib/Text_Wiki/Text/Wiki.php`) の rule 適用順 (Iftags は index 11、Comment は index 12) に整合: comment 内の iftags も普通に展開され、その後 comment rule が剥がす流れを保つ。

## Changes

### 新規

- `packages/parser/src/parser/rules/block/module/iftags/preprocess.ts`:
  - `preprocessIftags(source, pageTags)`: `pageTags === null` で no-op、それ以外は **innermost-first** に `[[iftags]]` を展開。
  - `INNERMOST_IFTAGS_PATTERN` に `g` flag を付与し、1 pass で全 innermost block を置換 (兄弟 iftags の `O(n^2)` 再走査を解消、反復回数は入れ子深さに比例)。
  - **raw region 保護**:
    - `[[code]]` (未閉じ時は EOF まで吸収)
    - `[[html]]` (close ある時のみ)
    - `@<...>@` (同一行)
    - `@@...@@` (同一行)
    - `RAW_BLOCK_OPEN_PATTERN` を sticky (`y`) + `lastIndex` 探索に変更し、per-`[[` の `source.slice(i)` 確保 (`O(n^2)`) を排除。close 探索も `g` + `lastIndex` で同様に slice 排除。
  - **placeholder sentinel** は Unicode Private Use Area chars。source 内に既出する場合は `makeUniqueSentinels` で衝突回避。
- `packages/parser/src/index.ts` に `preprocessIftags` を export。

### パイプライン更新

- `examples/wdmock-cf/apps/main/src/services/pipeline.ts`:
  - `resolveIncludes → getPageTags → preprocessIftags → parse → resolveModules` の順序に変更。

## Test plan

- [x] `[[iftags +tag]]` で tag を持つページは body を保持、持たないページは空に置換。
- [x] `[[iftags -tag]]` で逆方向の条件評価。
- [x] 入れ子の iftags が innermost-first で正しく評価される。
- [x] `[[code]]` / `[[html]]` / `@@..@@` / `@<..>@` 内の `[[iftags]]` は展開されない。
- [x] ブロック opener 属性内 (`[[div_ class="x" [[iftags +foo]]style="..."[[/iftags]]]]`) で展開される。
- [x] sibling iftags が多数あっても `O(n^2)` にならない。
- [x] lint / format / typecheck 通過。
- [x] unit 28 件 + integration 5 件、全体テスト通過。
