### PR TITLE
refactor(parser): `ParseContext`のper-scope fieldを`scope`groupに集約

### DIFF
--- a/packages/parser/src/parser/parse.ts
+++ b/packages/parser/src/parser/parse.ts
@@ -71,8 +71,6 @@ export class Parser {
       tocEntries: [],
       codeBlocks: [],
       htmlBlocks: [],
-      // State flags
-      footnoteBlockParsed: false,
       bibcites: [],
       // Diagnostics
       diagnostics: [],
@@ -80,6 +78,11 @@ export class Parser {
       blockRules,
       blockFallbackRule,
       inlineRules,
+      // Per-scope state — defaults; child contexts replace the whole
+      // `scope` object when they want to override a field.
+      scope: {
+        footnoteBlockParsed: false,
+      },
     };
   }
 

--- a/packages/parser/src/parser/rules/block/div.ts
+++ b/packages/parser/src/parser/rules/block/div.ts
@@ -89,7 +89,7 @@ export const divRule: BlockRule = {
     // more opens than closes, the innermost excess opens become text. We enforce
     // this with a "closes budget": the number of additional nested divs that can
     // open. When budget reaches 0, this div cannot open.
-    if (ctx.divClosesBudget === 0) {
+    if (ctx.scope.divClosesBudget === 0) {
       return { success: false };
     }
 
@@ -102,8 +102,8 @@ export const divRule: BlockRule = {
     // Calculate closes budget for nested divs in the body.
     // Count [[/div]] from body start to scope boundary, subtract 1 (for self).
     let bodyBudget: number | undefined;
-    if (ctx.divClosesBudget !== undefined) {
-      bodyBudget = ctx.divClosesBudget - 1;
+    if (ctx.scope.divClosesBudget !== undefined) {
+      bodyBudget = ctx.scope.divClosesBudget - 1;
     } else {
       const closesInScope = countDivCloses(ctx, pos);
       bodyBudget = closesInScope > 0 ? closesInScope - 1 : 0;
@@ -121,7 +121,11 @@ export const divRule: BlockRule = {
       return false;
     };
 
-    const bodyCtx: ParseContext = { ...ctx, pos, divClosesBudget: bodyBudget };
+    const bodyCtx: ParseContext = {
+      ...ctx,
+      pos,
+      scope: { ...ctx.scope, divClosesBudget: bodyBudget },
+    };
     let children: Element[];
 
     if (paragraphStrip) {

--- a/packages/parser/src/parser/rules/block/footnoteblock.ts
+++ b/packages/parser/src/parser/rules/block/footnoteblock.ts
@@ -12,8 +12,8 @@
  *
  * Wikidot only honours the FIRST `[[footnoteblock]]` in a document;
  * subsequent occurrences are treated as plain text. The parser tracks
- * this via `ctx.footnoteBlockParsed`, but note: that flag is per spread
- * copy of `ParseContext` (see {@link ParseContext.footnoteBlockParsed}).
+ * this via `ctx.scope.footnoteBlockParsed`, but note: that flag is per
+ * spread copy of `ParseContext` (see {@link ScopeContext.footnoteBlockParsed}).
  * In practice the duplicate-rejection only fires for two top-level
  * `[[footnoteblock]]` tokens; siblings inside the same body or across
  * nested bodies both succeed today. The auto-append decision in
@@ -111,12 +111,12 @@ function parseAttributes(
  * 1. Match BLOCK_OPEN + name "footnoteblock" (case-insensitive).
  * 2. Parse optional attributes (`title`, `hide`).
  * 3. Consume closing `]]`.
- * 4. If `ctx.footnoteBlockParsed` is already `true` on the current
+ * 4. If `ctx.scope.footnoteBlockParsed` is already `true` on the current
  *    `ParseContext` copy, fail. Because `parseBlocksUntil` spreads a
  *    fresh `ctx` per sibling rule, this only rejects a second
  *    `[[footnoteblock]]` that arrives via the parser's top-level
- *    dispatch loop in practice. See {@link ParseContext.footnoteBlockParsed}.
- * 5. Set `ctx.footnoteBlockParsed = true` and emit a `footnote-block`
+ *    dispatch loop in practice. See {@link ScopeContext.footnoteBlockParsed}.
+ * 5. Replace `ctx.scope` with the flag set to `true` and emit a `footnote-block`
  *    element.
  */
 export const footnoteBlockRule: BlockRule = {
@@ -170,12 +170,14 @@ export const footnoteBlockRule: BlockRule = {
 
     // Reject a second `[[footnoteblock]]` that arrives on the same
     // `ParseContext` copy (in practice: at the top level — siblings
-    // inside `parseBlocksUntil` each get a fresh spread). The
-    // cross-scope duplicate-rejection is a separate, known limitation.
-    if (ctx.footnoteBlockParsed) {
+    // inside `parseBlocksUntil` each get a fresh spread). The flag
+    // lives in the immutable `scope` group, so the mutation is
+    // expressed as a scope replacement. The cross-scope duplicate-
+    // rejection is a separate, known limitation.
+    if (ctx.scope.footnoteBlockParsed) {
       return { success: false };
     }
-    ctx.footnoteBlockParsed = true;
+    ctx.scope = { ...ctx.scope, footnoteBlockParsed: true };
 
     // Extract title and hide from attributes
     const title = attrs.title !== undefined ? attrs.title : null;

--- a/packages/parser/src/parser/rules/block/utils.ts
+++ b/packages/parser/src/parser/rules/block/utils.ts
@@ -49,7 +49,7 @@ function isNonBoundaryBlockToken(ctx: ParseContext, pos: number): boolean {
     // `[[` followed by no recognizable identifier -- treat as inline.
     return true;
   }
-  if (ctx.excludedBlockNames?.has(nameResult.name)) {
+  if (ctx.scope.excludedBlockNames?.has(nameResult.name)) {
     return true;
   }
   return !KNOWN_BLOCK_NAMES.has(nameResult.name);
@@ -167,8 +167,11 @@ export function parseBlocksUntil(
       ...ctx,
       pos,
       blockRules,
-      blockCloseCondition: closeCondition,
-      excludedBlockNames: excluded,
+      scope: {
+        ...ctx.scope,
+        blockCloseCondition: closeCondition,
+        excludedBlockNames: excluded,
+      },
     };
 
     for (const rule of blockRules) {

--- a/packages/parser/src/parser/rules/index.ts
+++ b/packages/parser/src/parser/rules/index.ts
@@ -18,7 +18,7 @@
  */
 
 // Types
-export type { ParseContext, RuleResult, BlockRule, InlineRule } from "./types";
+export type { ParseContext, ScopeContext, RuleResult, BlockRule, InlineRule } from "./types";
 export {
   currentToken,
   peekToken,

--- a/packages/parser/src/parser/rules/inline/utils.ts
+++ b/packages/parser/src/parser/rules/inline/utils.ts
@@ -13,11 +13,12 @@ import { parseBlockName } from "../utils";
  * names a block in the excluded set.
  */
 function isExcludedBlockToken(ctx: ParseContext, tokenPos: number): boolean {
-  if (!ctx.excludedBlockNames?.size) return false;
+  const excluded = ctx.scope.excludedBlockNames;
+  if (!excluded?.size) return false;
   const token = ctx.tokens[tokenPos];
   if (token?.type !== "BLOCK_OPEN" && token?.type !== "BLOCK_END_OPEN") return false;
   const nameResult = parseBlockName(ctx, tokenPos + 1);
-  return nameResult !== null && ctx.excludedBlockNames.has(nameResult.name);
+  return nameResult !== null && excluded.has(nameResult.name);
 }
 
 /**
@@ -106,9 +107,9 @@ export function parseInlineUntil(ctx: ParseContext, endType: TokenType): InlineP
 
     // Stop at block close condition if set in context
     // This allows paragraph parser to respect parent block's close condition
-    if (paragraphMode && ctx.blockCloseCondition) {
+    if (paragraphMode && ctx.scope.blockCloseCondition) {
       const checkCtx: ParseContext = { ...ctx, pos };
-      if (ctx.blockCloseCondition(checkCtx)) {
+      if (ctx.scope.blockCloseCondition(checkCtx)) {
         break;
       }
     }
@@ -178,7 +179,7 @@ export function parseInlineUntil(ctx: ParseContext, endType: TokenType): InlineP
           blockNameToken &&
           (blockNameToken.type === "TEXT" || blockNameToken.type === "IDENTIFIER") &&
           blockNameToken.value.toLowerCase() === "footnoteblock" &&
-          ctx.footnoteBlockParsed
+          ctx.scope.footnoteBlockParsed
         ) {
           isInvalidBlockOpen = true;
         }

--- a/packages/parser/src/parser/rules/types.ts
+++ b/packages/parser/src/parser/rules/types.ts
@@ -3,19 +3,40 @@ import type { Version, WikitextSettings, Diagnostic } from "@wdprlib/ast";
 import type { Element, CodeBlockData, TocEntry } from "@wdprlib/ast";
 
 /**
- * Parser context passed to rules
+ * Per-scope state propagated by spread + override semantics.
+ *
+ * Every field is `readonly` so a rule cannot accidentally mutate the
+ * parent scope by writing through a shared reference. Updates must be
+ * expressed as a replacement: `ctx.scope = { ...ctx.scope, X: ... }`
+ * (or, more commonly, by constructing a new child context with the
+ * desired scope override).
+ *
+ * The motivation is to keep speculative parse rollback safe: when a
+ * block rule fails, any scope it built up is discarded with the failed
+ * context. A shared-state design that mutates fields in place does not
+ * survive rollback — grouping per-scope fields here and forbidding
+ * nested mutation makes the semantics explicit at the type level.
  */
-export interface ParseContext {
-  tokens: Token[];
-  pos: number;
-  version: Version;
-  trackPositions: boolean;
-  settings: WikitextSettings;
-  // Collections for SyntaxTree output
-  footnotes: Element[][];
-  tocEntries: TocEntry[];
-  codeBlocks: CodeBlockData[];
-  htmlBlocks: string[];
+export interface ScopeContext {
+  /**
+   * Close condition for the current block. The paragraph parser calls
+   * it to decide when to stop collecting inline content.
+   */
+  readonly blockCloseCondition?: (ctx: ParseContext) => boolean;
+  /**
+   * Block names excluded from paragraph-boundary detection. When a
+   * BLOCK_OPEN/BLOCK_END_OPEN for an excluded name appears at line
+   * start, the inline parser does NOT treat it as a paragraph break.
+   * Used by `[[collapsible]]` to prevent nested `[[collapsible]]` from
+   * splitting paragraphs.
+   */
+  readonly excludedBlockNames?: ReadonlySet<string>;
+  /**
+   * Budget for div nesting: tracks how many more nested divs can open.
+   * When 0, the div rule fails (innermost excess opens become text).
+   * `undefined` means "not yet calculated" (top-level or non-div context).
+   */
+  readonly divClosesBudget?: number;
   /**
    * Used by the footnote-block rule to reject duplicate occurrences.
    *
@@ -42,26 +63,42 @@ export interface ParseContext {
    * The auto-append decision in `Parser.parse` deliberately ignores
    * this flag and walks the final AST instead — see `containsFootnoteBlock`.
    */
-  footnoteBlockParsed: boolean;
+  readonly footnoteBlockParsed: boolean;
+}
+
+/**
+ * Parser context passed to rules.
+ *
+ * Fields are grouped by lifecycle:
+ * - Static config (`tokens`, `version`, `trackPositions`, `settings`,
+ *   rule arrays): constructor-fixed.
+ * - `pos`: per-scope cursor; kept top-level for ergonomics because
+ *   every rule spread overrides it.
+ * - Accumulators (`footnotes`, `tocEntries`, …, `diagnostics`):
+ *   reference-shared via array identity across spreads.
+ * - `scope`: per-scope state explicitly grouped; see {@link ScopeContext}.
+ */
+export interface ParseContext {
+  tokens: Token[];
+  pos: number;
+  version: Version;
+  trackPositions: boolean;
+  settings: WikitextSettings;
+  // Collections for SyntaxTree output
+  footnotes: Element[][];
+  tocEntries: TocEntry[];
+  codeBlocks: CodeBlockData[];
+  htmlBlocks: string[];
   // Bibliography citation labels collected during parsing
   bibcites: string[];
   // Rules (injected to avoid circular dependency)
   blockRules: BlockRule[];
   blockFallbackRule: BlockRule;
   inlineRules: InlineRule[];
-  // Close condition for current block (passed to paragraph parser)
-  blockCloseCondition?: (ctx: ParseContext) => boolean;
-  // Block names excluded from paragraph-boundary detection.
-  // When a BLOCK_OPEN/BLOCK_END_OPEN for an excluded name appears at
-  // line start, the inline parser does NOT treat it as a paragraph break.
-  // Used by collapsible to prevent nested [[collapsible]] from splitting paragraphs.
-  excludedBlockNames?: ReadonlySet<string>;
   // Diagnostics collected during parsing
   diagnostics: Diagnostic[];
-  // Budget for div nesting: tracks how many more nested divs can open.
-  // When 0, div rule fails (innermost excess opens become text).
-  // undefined means "not yet calculated" (top-level or non-div context).
-  divClosesBudget?: number;
+  // Per-scope state (readonly fields, immutable-replace semantics).
+  scope: ScopeContext;
 }
 
 /**

--- a/tests/unit/parser/scope.test.ts
+++ b/tests/unit/parser/scope.test.ts
@@ -9,9 +9,23 @@
 
 import { describe, expect, it } from "bun:test";
 import { parse } from "@wdprlib/parser";
+import type { Element } from "@wdprlib/ast";
 
 function parseAst(src: string): ReturnType<typeof parse>["ast"] {
   return parse(src).ast;
+}
+
+function collectByElement(elements: readonly Element[], name: string): Element[] {
+  const out: Element[] = [];
+  const visit = (els: readonly Element[]): void => {
+    for (const el of els) {
+      if (el.element === name) out.push(el);
+      const data = (el as { data?: unknown }).data as { elements?: readonly Element[] } | undefined;
+      if (data && Array.isArray(data.elements)) visit(data.elements);
+    }
+  };
+  visit(elements);
+  return out;
 }
 
 describe("ParseContext.scope - per-scope semantics", () => {
@@ -29,15 +43,32 @@ describe("ParseContext.scope - per-scope semantics", () => {
       const fbs = ast.elements.filter((el) => el.element === "footnote-block");
       expect(fbs.length).toBe(1);
     });
+
+    it("nested [[footnoteblock]] inside [[div]] does not leak to outer scope", () => {
+      // The inner footnoteblock runs in a child scope (parseBlocksUntil
+      // spreads ctx for the div body). With per-scope semantics, the
+      // outer scope's flag stays false, so a subsequent top-level
+      // [[footnoteblock]] still emits its own footnote-block. The
+      // refactor must preserve this pre-existing behaviour.
+      const ast = parseAst("[[div]]\n[[footnoteblock]]\n[[/div]]\n\n[[footnoteblock]]");
+      const fbs = collectByElement(ast.elements, "footnote-block");
+      expect(fbs.length).toBe(2);
+    });
   });
 
   describe("divClosesBudget", () => {
-    it("balanced nested div opens parse successfully", () => {
-      // Smoke check: the scope group correctly propagates the budget into
-      // the nested div body so the inner [[div]] can still open.
+    it("balanced nested div opens parse successfully (inner container present)", () => {
+      // The scope group must propagate the budget into the nested div
+      // body so the inner [[div]] still opens. Drilling into the outer
+      // container's `elements` proves the inner container survives.
       const ast = parseAst("[[div]]\nA\n[[div]]\nB\n[[/div]]\nC\n[[/div]]");
-      const containers = ast.elements.filter((el) => el.element === "container");
-      expect(containers.length).toBeGreaterThanOrEqual(1);
+      const containers = collectByElement(ast.elements, "container");
+      // Outer + inner div + possibly inner paragraphs — at least 2 containers.
+      const divContainers = containers.filter((c) => {
+        const data = (c as { data?: { type?: unknown } }).data;
+        return data?.type === "div" || data?.type === "div_";
+      });
+      expect(divContainers.length).toBe(2);
     });
 
     it("unbalanced excess opens become text (budget enforcement)", () => {
@@ -45,9 +76,14 @@ describe("ParseContext.scope - per-scope semantics", () => {
       // text, not a successful container. Confirms divClosesBudget is
       // threaded through the scope group correctly.
       const ast = parseAst("[[div]]\n[[div]]\nbody\n[[/div]]");
-      // Exactly one container survives; the other [[div]] becomes text.
-      const containers = ast.elements.filter((el) => el.element === "container");
-      expect(containers.length).toBe(1);
+      const containers = collectByElement(ast.elements, "container");
+      const divContainers = containers.filter((c) => {
+        const data = (c as { data?: { type?: unknown } }).data;
+        return data?.type === "div" || data?.type === "div_";
+      });
+      // Exactly one [[div]] container survives; the inner excess open
+      // becomes text inside the outer container's body.
+      expect(divContainers.length).toBe(1);
     });
   });
 });

--- a/tests/unit/parser/scope.test.ts
+++ b/tests/unit/parser/scope.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression tests for ParseContext per-scope semantics.
+ *
+ * After grouping the per-scope fields into `ctx.scope`, the observable
+ * behaviour for `footnoteBlockParsed` and `divClosesBudget` must match
+ * the pre-refactor parser: top-level mutations stick, but mutations
+ * inside a child scope spread do not leak back to the parent.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { parse } from "@wdprlib/parser";
+
+function parseAst(src: string): ReturnType<typeof parse>["ast"] {
+  return parse(src).ast;
+}
+
+describe("ParseContext.scope - per-scope semantics", () => {
+  describe("footnoteBlockParsed", () => {
+    it("a single [[footnoteblock]] produces exactly one footnote-block", () => {
+      const ast = parseAst("text\n\n[[footnoteblock]]");
+      const fbs = ast.elements.filter((el) => el.element === "footnote-block");
+      expect(fbs.length).toBe(1);
+    });
+
+    it("two top-level [[footnoteblock]] only emit one (top-level mutation sticks)", () => {
+      // The first occurrence mutates the parser's main ctx scope; the
+      // second sees the flag set and falls through to text.
+      const ast = parseAst("[[footnoteblock]]\n\n[[footnoteblock]]");
+      const fbs = ast.elements.filter((el) => el.element === "footnote-block");
+      expect(fbs.length).toBe(1);
+    });
+  });
+
+  describe("divClosesBudget", () => {
+    it("balanced nested div opens parse successfully", () => {
+      // Smoke check: the scope group correctly propagates the budget into
+      // the nested div body so the inner [[div]] can still open.
+      const ast = parseAst("[[div]]\nA\n[[div]]\nB\n[[/div]]\nC\n[[/div]]");
+      const containers = ast.elements.filter((el) => el.element === "container");
+      expect(containers.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("unbalanced excess opens become text (budget enforcement)", () => {
+      // Two opens and one close: the innermost excess open must become
+      // text, not a successful container. Confirms divClosesBudget is
+      // threaded through the scope group correctly.
+      const ast = parseAst("[[div]]\n[[div]]\nbody\n[[/div]]");
+      // Exactly one container survives; the other [[div]] becomes text.
+      const containers = ast.elements.filter((el) => el.element === "container");
+      expect(containers.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `ParseContext` の per-scope semantics を持つ 4 フィールド (`footnoteBlockParsed` / `divClosesBudget` / `blockCloseCondition` / `excludedBlockNames`) を新しい `ScopeContext` interface に集約。
- `ScopeContext` の field は全て `readonly`。spread で参照共有されるオブジェクトだが mutation は禁止し、`ctx.scope = { ...ctx.scope, X: ... }` の **immutable replace** で行う。
- 型レベルで「これは per-scope semantics」が明示され、TS が nested mutation (`ctx.scope.X = ...`) を error にする。投機 parse rollback safe (失敗した child context の scope は破棄される)。

## 背景

`ParseContext` は用途の異なる field がフラットに並んでおり、特に primitive 型 (`footnoteBlockParsed: boolean`) は spread copy で per-scope semantics になっているのに、名前から見ると「global per-document flag」のように見えた。同様のリスクが他フィールドにも潜在しており、型レベルで semantics を明示するのが本リファクタの目的。

## Changes

### 1. 型定義 (`packages/parser/src/parser/rules/types.ts`)

- `ScopeContext` interface 追加。全 field `readonly`:
  - `readonly blockCloseCondition?: (ctx: ParseContext) => boolean`
  - `readonly excludedBlockNames?: ReadonlySet<string>`
  - `readonly divClosesBudget?: number`
  - `readonly footnoteBlockParsed: boolean`
- `ParseContext` から上記 4 field を削除し、`scope: ScopeContext` を追加。
- `pos` は per-scope cursor だが頻出のため top-level に例外的に残置 (理由を JSDoc に明記)。
- accumulator (`footnotes` / `tocEntries` / `codeBlocks` / `htmlBlocks` / `bibcites` / `diagnostics`) は top-level のまま (配列参照 spread 共有でそのまま機能)。

### 2. 利用側

- `packages/parser/src/parser/parse.ts`:
  - constructor で `scope: { footnoteBlockParsed: false }` を初期化。
- `packages/parser/src/parser/rules/block/div.ts`:
  - `ctx.divClosesBudget` を `ctx.scope.divClosesBudget` に。
  - spread を `{ ...ctx, pos, scope: { ...ctx.scope, divClosesBudget: bodyBudget } }` に。
- `packages/parser/src/parser/rules/block/footnoteblock.ts`:
  - 判定を `ctx.scope.footnoteBlockParsed` に。
  - mutation を `ctx.scope = { ...ctx.scope, footnoteBlockParsed: true }` の immutable replace に。`readonly` のため nested `ctx.scope.X = ...` は TS error。
- `packages/parser/src/parser/rules/block/utils.ts`:
  - `parseBlocksUntil` の spread で `blockCloseCondition` / `excludedBlockNames` を `scope` 経由に。
- `packages/parser/src/parser/rules/inline/utils.ts`:
  - `excludedBlockNames` / `blockCloseCondition` / `footnoteBlockParsed` の参照を `ctx.scope.*` に。
- `packages/parser/src/parser/rules/index.ts`:
  - `ScopeContext` を internal type export に追加。

### 3. テスト (`tests/unit/parser/scope.test.ts`)

- `collectByElement` helper で AST を再帰走査。
- 単一の `[[footnoteblock]]` がちょうど 1 個の `footnote-block` を生む。
- 二回目の top-level `[[footnoteblock]]` は text として扱われる (top-level mutation sticks)。
- `[[div]]` 内の `[[footnoteblock]]` + top-level `[[footnoteblock]]` で `footnote-block` が 2 個出る (per-scope 非伝播の確認)。
- balanced nested `[[div]]` の内側 div が container として残る (`scope.divClosesBudget` 経由)。
- unbalanced excess `[[div]]` opens が text 化される (budget enforcement)。

## BREAKING CHANGE

- `ParseContext` に必須プロパティ `scope: ScopeContext` を追加し、`footnoteBlockParsed` / `divClosesBudget` / `blockCloseCondition` / `excludedBlockNames` を top-level から削除。
- 外部で `ParseContext` 互換オブジェクトを手書きしている消費者は `scope: { footnoteBlockParsed: false, ... }` の追加が必要。
- `ParseContext` は内部公開型 (`rules/types.ts`、`@wdprlib/parser` の internal index 経由) で、通常の `parse()` / `Parser` クラス経由なら影響なし。

## Test plan

- [x] 全体テスト通過 (`bun test` で 1178 件)。
- [x] lint / format / typecheck 通過。
- [x] per-scope semantics の回帰テスト (top-level mutation sticks / nested non-leak / div budget 成功・text 化区別) 追加。
- [x] `rg "ctx\.scope\..*= "` で nested mutation の writebacks が残っていないことを確認 (immutable replace 以外の書き込みなし)。