### PR TITLE
feat(parser): opener-embedded [[iftags]]をparse()で解決

### DIFF
--- a/examples/wdmock-cf/apps/main/src/services/pipeline.ts
+++ b/examples/wdmock-cf/apps/main/src/services/pipeline.ts
@@ -3,13 +3,7 @@
  *
  * Handles source parsing, module resolution, and HTML rendering.
  */
-import {
-  parse,
-  extractDataRequirements,
-  resolveModules,
-  resolveIncludes,
-  preprocessIftags,
-} from "@wdprlib/parser";
+import { parse, extractDataRequirements, resolveModules, resolveIncludes } from "@wdprlib/parser";
 import type {
   NormalizedListPagesQuery,
   ListPagesExternalData,
@@ -54,18 +48,17 @@ export async function renderPage(
     return pageSourceMap.get(pageRef.page) ?? null;
   });
 
-  // Fetch the page's tags before parsing so source-level [[iftags]]
-  // (e.g. inside a [[div_]] opener attribute, which the AST resolver
-  // cannot reach because it would be eaten as garbage by the block
-  // tokenizer) can be expanded against them.
+  // Fetch the page's tags so source-level [[iftags]] inside block openers
+  // (e.g. `[[div_ class="x" [[iftags +foo]]...[[/iftags]]]]`) can be
+  // collapsed text-level by parse() — otherwise the block-level tokenizer
+  // would emit the whole opener as raw text.
   const pageTags = await getTagsByFullname(
     db,
     parseFullname(pageName).category,
     parseFullname(pageName).name,
   );
 
-  const preprocessed = preprocessIftags(expanded, pageTags);
-  const { ast: resolved, diagnostics: _diagnostics = [] } = parse(preprocessed);
+  const { ast: resolved, diagnostics: _diagnostics = [] } = parse(expanded, { pageTags });
 
   const { requirements, compiledListPagesTemplates } = extractDataRequirements(resolved);
 
@@ -78,7 +71,7 @@ export async function renderPage(
       getPageTags: () => pageTags,
     },
     {
-      parse: (input: string) => parse(input).ast,
+      parse: (input: string) => parse(input, { pageTags }).ast,
       compiledListPagesTemplates,
       requirements,
       urlPath: options?.urlPath,

--- a/packages/parser/src/parser/parse.ts
+++ b/packages/parser/src/parser/parse.ts
@@ -12,6 +12,7 @@ import {
 } from "./postprocess";
 import { buildTableOfContents } from "./toc";
 import { walkElements } from "./rules/block/module/walk";
+import { preprocessIftags } from "./rules/block/module/iftags/preprocess";
 
 /**
  * Configuration for the {@link Parser} and the {@link parse} function.
@@ -34,6 +35,25 @@ export interface ParserOptions {
    * Defaults to {@link DEFAULT_SETTINGS} (full page mode).
    */
   settings?: WikitextSettings;
+  /**
+   * Page tags consulted when expanding `[[iftags]]` directives that are
+   * embedded inside another block's opener — e.g.
+   * `[[div_ class="x" [[iftags +foo]]style="..."[[/iftags]]]]`. Such
+   * iftags must be collapsed at text level *before* tokenization;
+   * otherwise the outer opener loses its well-formed structure and the
+   * whole `[[div_ ... ]]` line is emitted as raw text.
+   *
+   * Values:
+   * - omitted / `undefined`: no preprocess pass. Existing behaviour;
+   *   opener-embedded iftags will still break the surrounding opener.
+   * - `null`: opener-embedded iftags only, evaluated as if the page has
+   *   no tags (lossy fallback that keeps tokenization working when real
+   *   tags are unknown). Block-level iftags remain in the AST for
+   *   `resolveModules` to evaluate later via `getPageTags`.
+   * - `string[]`: every iftags block is evaluated against the given
+   *   tags eagerly; no `if-tags` nodes survive in the AST.
+   */
+  pageTags?: string[] | null;
 }
 
 /**
@@ -253,7 +273,13 @@ export class Parser {
  * @since 2.0.0
  */
 export function parse(source: string, options?: ParserOptions): ParseResult {
-  const preprocessed = preprocess(source);
+  // Collapse opener-embedded [[iftags]] before tokenization. Only run when
+  // the caller explicitly opted in via the `pageTags` option (key present).
+  // `undefined` is treated as "key not given" to keep backward compat for
+  // callers that destructure or build options dynamically.
+  const iftagsProcessed =
+    options?.pageTags !== undefined ? preprocessIftags(source, options.pageTags) : source;
+  const preprocessed = preprocess(iftagsProcessed);
   const tokens = tokenize(preprocessed, { trackPositions: options?.trackPositions });
   return new Parser(tokens, options).parse();
 }

--- a/packages/parser/src/parser/rules/block/module/iftags/preprocess.ts
+++ b/packages/parser/src/parser/rules/block/module/iftags/preprocess.ts
@@ -15,14 +15,27 @@
  * The block-level tokenizer cannot recover a well-formed opener from
  * that input — the inner `[[iftags ...]]X[[/iftags]]` has to collapse
  * to either `X` or the empty string *before* the parser sees the outer
- * tag, so the attribute string becomes plain text again. The AST-level
- * `[[iftags]]` block rule still exists and handles cases where the
- * preprocess pass is skipped (`pageTags === null`).
+ * tag, so the attribute string becomes plain text again.
  *
- * Pipeline order:
+ * `pageTags` semantics:
+ *
+ * - `string[]`: full pass. Every `[[iftags]]` is evaluated against the
+ *   given tag set and collapses to either its body or the empty string.
+ *   The AST will contain no `if-tags` nodes after parsing.
+ * - `null`: tags are unknown (e.g. draft preview, fixture test).
+ *   The pass still runs but only collapses `[[iftags]]` blocks that are
+ *   embedded inside another block's opener (`[[name ... [[iftags ...]]X[[/iftags]] ... ]]`).
+ *   Block-level `[[iftags]]` are left alone for {@link resolveIfTags}
+ *   to evaluate later when real tags are supplied via `getPageTags`.
+ *   Opener-embedded iftags are collapsed using an empty-tag assumption
+ *   (i.e. `+tag` conditions fail, `-tag` conditions pass). This is a
+ *   lossy fallback that keeps the outer block parseable; callers that
+ *   need accurate rendering should pass the real tags as `string[]`.
+ *
+ * Pipeline order (when invoked via `parse()`):
  *
  * ```
- * getPageTags → resolveIncludes → preprocessIftags(source, pageTags) → parse → resolveModules
+ * getPageTags → resolveIncludes → parse({ pageTags }) → resolveModules
  * ```
  *
  * Running this after include expansion is intentional: an included
@@ -73,24 +86,23 @@ const RAW_BLOCK_OPEN_PATTERN = /\[\[\s*(code|html)\b[^\]]*\]\]/iy;
  * Expand `[[iftags ...]]X[[/iftags]]` directives in `source` against the
  * current page's tags.
  *
- * Returns `source` unchanged when `pageTags` is `null`, which signals
- * that the caller could not resolve tag membership (e.g. rendering a
- * draft preview without a real page). In that case the AST-level
- * resolver remains responsible for evaluation later.
- *
  * Behaviour:
  * - Raw regions (`[[code]]`, `[[html]]`, `@@...@@`, `@<...>@`) are
  *   protected: literal `[[iftags]]` tokens inside them are not expanded.
  * - Nested `[[iftags]]` are processed innermost-first, so an outer
  *   block can re-process the now-flattened inner body uniformly.
+ * - `pageTags === null`: only `[[iftags]]` blocks embedded inside
+ *   another block's opener are collapsed (using an empty-tag fallback
+ *   so `+tag` conditions fail and `-tag` conditions pass). Block-level
+ *   iftags are left intact for the AST-level resolver.
  *
  * @param source   Raw wikitext (typically after include expansion).
- * @param pageTags Tags of the page being rendered, or `null` to skip.
+ * @param pageTags Tags of the page being rendered, or `null` for the
+ *                 opener-embedded-only fallback mode.
  * @returns Source with matching iftags replaced by their bodies and
  *          unmatched iftags removed entirely.
  */
 export function preprocessIftags(source: string, pageTags: string[] | null): string {
-  if (pageTags === null) return source;
   if (!source.includes("[[")) return source; // fast path
 
   const sentinels = makeUniqueSentinels(source);
@@ -124,31 +136,184 @@ function makeUniqueSentinels(source: string): { open: string; close: string } {
 
 /**
  * Replace `[[iftags ...]]X[[/iftags]]` blocks innermost-first until no
- * iftags pair remains. The pattern is global, so each pass rewrites all
- * innermost blocks at once and thus eliminates one nesting level;
- * matched blocks become their body (if the condition holds) or the empty
- * string (otherwise).
+ * iftags pair remains.
  *
- * The loop terminates because every pass that changes the string removes
- * at least one nesting level. If the regex fails to match (no more
- * pairs, or unbalanced leftovers), the loop exits with the partially
- * reduced source.
+ * Behaviour by `pageTags`:
+ * - `string[]`: every match collapses to body / empty based on tag membership.
+ * - `null`: only matches whose start offset has `bracketDepth > 0`
+ *   (i.e. embedded inside an outer block opener) are collapsed, using
+ *   an empty-tag assumption. Block-level matches are returned verbatim
+ *   so {@link resolveIfTags} can evaluate them later.
+ *
+ * The loop terminates when a pass changes nothing.
  */
-function reduceIftags(source: string, pageTags: string[]): string {
+function reduceIftags(source: string, pageTags: string[] | null): string {
   let current = source;
   // Worst-case bound: one pass eliminates at least one nesting level, and
   // nesting depth is at most `source.length`. The explicit cap stops a
   // runaway regex (e.g. pathological zero-width match) from looping forever.
   const maxIterations = source.length + 1;
+  const tagSet: string[] = pageTags ?? [];
   for (let i = 0; i < maxIterations; i++) {
-    const next = current.replace(INNERMOST_IFTAGS_PATTERN, (_, cond: string, body: string) => {
-      const condition = parseTagCondition(cond);
-      return evaluateTagCondition(condition, pageTags) ? body : "";
-    });
-    if (next === current) return current;
+    const depths = pageTags === null ? computeBracketDepths(current) : null;
+    let changed = false;
+    const next = current.replace(
+      INNERMOST_IFTAGS_PATTERN,
+      (match, cond: string, body: string, offset: number) => {
+        if (depths !== null && depths[offset] === 0) {
+          // block-level iftags in `null` mode → leave for AST resolver
+          return match;
+        }
+        changed = true;
+        const condition = parseTagCondition(cond);
+        return evaluateTagCondition(condition, tagSet) ? body : "";
+      },
+    );
+    if (!changed) return current;
     current = next;
   }
   return current;
+}
+
+/**
+ * Compute the unmatched-`[[` depth at each character offset of `masked`.
+ *
+ * Approximates the lexer's `blockOpenerDepth` (see `lexer.ts`):
+ * - `[[` increments, `]]` decrements (clamped at 0).
+ * - `[[[ ... ]]]` triple-bracket links are LINK_OPEN/LINK_CLOSE in the
+ *   lexer and do **not** participate in block-opener depth — skipped
+ *   here so that an `[[iftags]]` inside a link text is not misclassified
+ *   as opener-embedded.
+ * - Inside an opener context (`depth > 0`) a `"` preceded by `=` (with
+ *   only whitespace in between) opens a quoted attribute value; its
+ *   contents are skipped until the next `"` or `\n`, mirroring
+ *   `lexer.ts` `QUOTED_STRING` recognition. This protects opener-internal
+ *   `]]` inside attribute strings from being counted as block closers.
+ *
+ * The returned array has length `masked.length + 1` and `depths[k]`
+ * represents the depth **immediately before** the character at offset
+ * `k` is consumed. `INNERMOST_IFTAGS_PATTERN` returns offsets at the
+ * leading `[` of `[[iftags`, so `depths[offset]` is the depth of the
+ * surrounding context.
+ */
+function computeBracketDepths(masked: string): Int32Array {
+  const n = masked.length;
+  const depths = new Int32Array(n + 1);
+  let depth = 0;
+  let i = 0;
+  while (i < n) {
+    depths[i] = depth;
+    const c = masked.charCodeAt(i);
+    const c1 = i + 1 < n ? masked.charCodeAt(i + 1) : -1;
+    const c2 = i + 2 < n ? masked.charCodeAt(i + 2) : -1;
+
+    // Quoted attribute value inside an opener context.
+    if (depth > 0 && c === 0x22 /* " */ && precededByEqualsAttr(masked, i)) {
+      const end = findQuoteEnd(masked, i + 1);
+      for (let k = i; k <= end; k++) depths[k] = depth;
+      i = end + 1;
+      continue;
+    }
+
+    // Triple-bracket link: [[[ ... ]]] does not change opener depth.
+    if (c === 0x5b /* [ */ && c1 === 0x5b && c2 === 0x5b) {
+      const end = findTripleLinkEnd(masked, i + 3);
+      for (let k = i; k <= end; k++) depths[k] = depth;
+      i = end + 1;
+      continue;
+    }
+
+    if (c === 0x5b && c1 === 0x5b) {
+      depth++;
+      depths[i + 1] = depth;
+      i += 2;
+      continue;
+    }
+
+    if (c === 0x5d /* ] */ && c1 === 0x5d) {
+      depth = Math.max(0, depth - 1);
+      depths[i + 1] = depth;
+      i += 2;
+      continue;
+    }
+
+    if (c === 0x0a /* \n */) {
+      // Reset depth at line boundaries: Wikidot block openers are
+      // single-line constructs, so an unterminated `[[xxx` that spills
+      // past a newline should not keep subsequent block-level iftags
+      // inside its (imaginary) opener context. Without this reset,
+      // `[[broken\n[[iftags +foo]]body[[/iftags]]` would misclassify
+      // the iftags as opener-embedded and collapse it instead of
+      // deferring evaluation to the AST resolver.
+      depth = 0;
+    }
+
+    i++;
+  }
+  depths[n] = depth;
+  return depths;
+}
+
+/**
+ * Return `true` when position `i` of `s` is preceded (after skipping
+ * spaces/tabs) by a literal `=` character — the lexer's condition for
+ * promoting a following `"` to a `QUOTED_STRING` token. Newlines are
+ * treated as non-equals so an unterminated `=` on a previous line does
+ * not arm quote recognition for arbitrary `"` later on.
+ */
+function precededByEqualsAttr(s: string, i: number): boolean {
+  let j = i - 1;
+  while (j >= 0) {
+    const ch = s.charCodeAt(j);
+    if (ch === 0x20 /* space */ || ch === 0x09 /* tab */) {
+      j--;
+      continue;
+    }
+    return ch === 0x3d; /* = */
+  }
+  return false;
+}
+
+/**
+ * Find the offset of the closing `"` (or terminating `\n`) for a quoted
+ * attribute value that opens at `from`. Returns the offset of the
+ * terminator. Mirrors the lexer's behaviour of stopping at newline.
+ */
+function findQuoteEnd(s: string, from: number): number {
+  for (let i = from; i < s.length; i++) {
+    const ch = s.charCodeAt(i);
+    if (ch === 0x22 /* " */ || ch === 0x0a /* \n */) return i;
+  }
+  return s.length - 1;
+}
+
+/**
+ * Find the end offset of a `[[[ ... ]]]` triple-bracket link starting
+ * at `from` (the position immediately after the opening `[[[`).
+ *
+ * Conservative termination: stops at the first `]]]`, at a blank line
+ * (two consecutive `\n`), or at EOF. Wikidot's link parser also bails
+ * out on multi-line link bodies, so a `[[[` with no matching `]]]`
+ * inside a paragraph is treated as a one-paragraph region for depth
+ * purposes. The exact semantics of inner content do not matter here —
+ * we only need to ensure block-opener depth is not inflated by `[[` /
+ * `]]` that the lexer would never see as block markers.
+ */
+function findTripleLinkEnd(s: string, from: number): number {
+  for (let i = from; i < s.length; i++) {
+    if (
+      s.charCodeAt(i) === 0x5d &&
+      i + 2 < s.length &&
+      s.charCodeAt(i + 1) === 0x5d &&
+      s.charCodeAt(i + 2) === 0x5d
+    ) {
+      return i + 2;
+    }
+    if (s.charCodeAt(i) === 0x0a && i + 1 < s.length && s.charCodeAt(i + 1) === 0x0a) {
+      return i;
+    }
+  }
+  return s.length - 1;
 }
 
 /**

--- a/tests/unit/module/iftags/preprocess.test.ts
+++ b/tests/unit/module/iftags/preprocess.test.ts
@@ -3,7 +3,8 @@ import { preprocessIftags } from "../../../../packages/parser/src/parser/rules/b
 
 describe("preprocessIftags", () => {
   describe("pass-through", () => {
-    test("returns source unchanged when pageTags is null", () => {
+    test("block-level [[iftags]] is left intact when pageTags is null", () => {
+      // null mode defers block-level evaluation to the AST resolver.
       const src = "before [[iftags +foo]]inside[[/iftags]] after";
       expect(preprocessIftags(src, null)).toBe(src);
     });
@@ -14,6 +15,60 @@ describe("preprocessIftags", () => {
 
     test("fast-path when source contains no [[ at all", () => {
       expect(preprocessIftags("no brackets here", ["foo"])).toBe("no brackets here");
+    });
+  });
+
+  describe("null mode: opener-embedded fallback", () => {
+    // When pageTags is null the caller could not resolve tag membership.
+    // Opener-embedded iftags still have to collapse text-level (otherwise
+    // the surrounding block opener fails to tokenize). They are evaluated
+    // with an empty-tag assumption: `+tag` fails, `-tag` passes.
+    test("collapses opener-embedded iftags with empty-tag fallback (+tag fails)", () => {
+      const src = `[[div_ class="x" [[iftags +foo]]style="display:none;"[[/iftags]]]]`;
+      expect(preprocessIftags(src, null)).toBe(`[[div_ class="x" ]]`);
+    });
+
+    test("collapses opener-embedded iftags with empty-tag fallback (-tag passes)", () => {
+      const src = `[[div_ class="x" [[iftags -foo]]style="display:none;"[[/iftags]]]]`;
+      expect(preprocessIftags(src, null)).toBe(`[[div_ class="x" style="display:none;"]]`);
+    });
+
+    test("leaves opener-embedded iftags inside a [[code]] raw region intact", () => {
+      const src = `[[code]][[div_ class="x" [[iftags +foo]]X[[/iftags]]]][[/code]]`;
+      expect(preprocessIftags(src, null)).toBe(src);
+    });
+
+    test("quoted attribute containing literal ]] does not break depth tracking", () => {
+      // The `]]` inside a quoted attribute value must not count as a
+      // block-close; otherwise the trailing iftags would be misclassified
+      // as block-level and slip through unchanged.
+      const src = `[[div_ title="hello ]]" [[iftags +foo]]bad[[/iftags]]]]`;
+      expect(preprocessIftags(src, null)).toBe(`[[div_ title="hello ]]" ]]`);
+    });
+
+    test("triple-link [[[ ... ]]] does not inflate bracket depth", () => {
+      // An iftags appearing AFTER a triple-link must remain block-level.
+      const src = `[[[somepage]]]\n[[iftags +foo]]body[[/iftags]]`;
+      expect(preprocessIftags(src, null)).toBe(src);
+    });
+
+    test("handles nested opener-embedded iftags (innermost first)", () => {
+      const src = `[[div_ [[iftags -a]]outer[[iftags +b]]inner[[/iftags]][[/iftags]] ]]`;
+      // With pageTags=null, evaluate against []:
+      //   inner: +b fails -> ""
+      //   then outer: -a passes -> "outer" + "" = "outer"
+      expect(preprocessIftags(src, null)).toBe(`[[div_ outer ]]`);
+    });
+
+    test("malformed unterminated [[ on a preceding line does not swallow later block-level iftags", () => {
+      // Without a depth reset at newline boundaries, the leading
+      // `[[broken` would keep depth > 0 across the newline and the
+      // second line's iftags would be misclassified as opener-embedded.
+      // The depth must reset at `\n` so that block-level iftags after
+      // a malformed line are still left for the AST resolver.
+      const src = `[[broken
+[[iftags +foo]]body[[/iftags]]`;
+      expect(preprocessIftags(src, null)).toBe(src);
     });
   });
 

--- a/tests/unit/parser/parser.test.ts
+++ b/tests/unit/parser/parser.test.ts
@@ -445,4 +445,73 @@ describe("Parser", () => {
       expect(img.data.attributes).toEqual({ alt: "Description", width: "100" });
     });
   });
+
+  describe("pageTags option (opener-embedded [[iftags]])", () => {
+    const OPENER_EMBEDDED = `[[div_ class="rateBox" [[iftags +highlight]]style="display:none;"[[/iftags]]]]
+inside
+[[/div_]]`;
+
+    function findDivContainer(
+      elements: readonly Element[],
+    ): (Element & { element: "container" }) | undefined {
+      return elements.find(
+        (el): el is Element & { element: "container" } =>
+          el.element === "container" && (el.data as { type: string }).type === "div",
+      );
+    }
+
+    function hasIfTags(els: readonly Element[]): boolean {
+      return els.some((el) => {
+        if (el.element === "if-tags") return true;
+        const data = (el as { data?: unknown }).data;
+        if (data && typeof data === "object" && "elements" in data) {
+          const children = (data as { elements?: unknown }).elements;
+          if (Array.isArray(children)) return hasIfTags(children as Element[]);
+        }
+        return false;
+      });
+    }
+
+    it("without pageTags option, opener-embedded iftags break the surrounding opener", () => {
+      // Backward-compat: parse(src) is unchanged. The opener fails to
+      // tokenize, so no `div`-type container is produced — the line falls
+      // through to the paragraph fallback rule instead.
+      const doc = parseAst(OPENER_EMBEDDED);
+      const content = getContentElements(doc);
+      expect(findDivContainer(content)).toBeUndefined();
+    });
+
+    it("pageTags: [] collapses opener-embedded iftags with empty tags (+tag fails)", () => {
+      const doc = parseAst(OPENER_EMBEDDED, { pageTags: [] });
+      const content = getContentElements(doc);
+      const container = findDivContainer(content);
+      expect(container).toBeDefined();
+      // style="display:none;" is dropped because +highlight fails against [].
+      const attrs = (container!.data as { attributes?: Record<string, string> }).attributes ?? {};
+      expect(attrs.class).toBe("rateBox");
+      expect(attrs.style).toBeUndefined();
+    });
+
+    it("pageTags: ['highlight'] keeps the conditional style attribute", () => {
+      const doc = parseAst(OPENER_EMBEDDED, { pageTags: ["highlight"] });
+      const content = getContentElements(doc);
+      const container = findDivContainer(content);
+      expect(container).toBeDefined();
+      const attrs = (container!.data as { attributes?: Record<string, string> }).attributes ?? {};
+      expect(attrs.class).toBe("rateBox");
+      expect(attrs.style).toBe("display:none;");
+    });
+
+    it("pageTags: null collapses opener-embedded with empty-tag fallback but keeps block-level iftags", () => {
+      const src = `${OPENER_EMBEDDED}
+
+[[iftags +foo]]conditional[[/iftags]]`;
+      const doc = parseAst(src, { pageTags: null });
+      const content = getContentElements(doc);
+      // Opener-embedded one becomes a valid div container.
+      expect(findDivContainer(content)).toBeDefined();
+      // Block-level iftags survives in the AST for the resolver.
+      expect(hasIfTags(content)).toBe(true);
+    });
+  });
 });

--- a/tests/unit/parser/resolve/preprocess-iftags-integration.test.ts
+++ b/tests/unit/parser/resolve/preprocess-iftags-integration.test.ts
@@ -54,11 +54,10 @@ describe("preprocessIftags + parse + render integration", () => {
     expect(html).toContain("[[iftags +foo]]X[[/iftags]]");
   });
 
-  it("falls back to AST-level handling when pageTags is null", () => {
-    // null pageTags → preprocess is a no-op. The AST-level [[iftags]]
-    // block rule still parses the construct (and resolveModules would
-    // evaluate it later). At this layer (no resolveModules call) the
-    // if-tags element ends up in the AST with its body preserved.
+  it("block-level [[iftags]] under pageTags=null is left for the AST resolver", () => {
+    // null pageTags only collapses opener-embedded iftags as a fallback.
+    // Block-level iftags survives in the AST so resolveModules can later
+    // evaluate it against the real tag set.
     const src = `[[iftags +foo]]body[[/iftags]]`;
     const preprocessed = preprocessIftags(src, null);
     expect(preprocessed).toBe(src);


### PR DESCRIPTION
## 背景

`[[div_ class="x" [[iftags +foo]]style="display:none;"[[/iftags]]]]` のようにブロックオープナーの属性リスト内に `[[iftags ...]]X[[/iftags]]` を埋め込んだ書式は、Wikidot の credit module 等で広く使われている。しかし現状の `parse()` 単独呼び出しでは、トークナイザが well-formed なオープナーを復元できず、`[[div_]]` 行全体が生テキストとして出力されていた。

text-level の `preprocessIftags(source, pageTags)` は元々用意されていたが、`parse()` から呼ばれない上に `pageTags === null` で完全 no-op だったため、タグが未取得の経路では opener-embedded iftags が必ず破綻していた。

## 変更点

### `ParserOptions.pageTags?: string[] | null` を新規追加

`parse(source, options)` のオプションで text-level preprocess を起動する:

| 値 | 挙動 |
|---|---|
| 未指定 (`undefined`) | preprocess を呼ばない。既存挙動と完全に同じ。 |
| `null` | opener-embedded iftags のみ空タグ仮定で text-level に畳む lossy fallback。block-level iftags は AST に残り`resolveModules` の `getPageTags` で評価される。 |
| `[]` | 既知の空タグとして全 `[[iftags]]` を eager に評価。 |
| `string[]` | 既知のタグ集合で全 `[[iftags]]` を eager に評価。 |

`options?.pageTags !== undefined` でキー存在を判定するため、`undefined` を明示的に渡しても従来挙動を維持する（dynamic options 構築への配慮）。

### `preprocessIftags(source, null)` の挙動変更

これまで完全 no-op だったのを「opener-embedded iftags のみ畳む」に変更。block-level iftags はそのまま残るため AST resolver の責務は不変。

### depth 判定のオープナーコンテキスト識別

lexer の `blockOpenerDepth` 挙動に合わせて以下を考慮:

- attribute quote (`= "..."`) は同一行内のみ skip（`packages/parser/src/lexer/lexer.ts` の QUOTED_STRING 認識と同条件）
- `[[[ ... ]]]` triple-bracket link は LINK_OPEN/LINK_CLOSE として depth に算入しない
- 改行で depth をリセット（block opener は単一行構造のため、未閉 `[[xxx` が後続の block-level `[[iftags]]` を巻き込まないようにする）

### wdmock-cf pipeline の整理

明示的 `preprocessIftags` 呼び出しを削除し、`parse(.., { pageTags })` と`resolveModules` の `parse` callback に集約。挙動は不変。ListPages テンプレートの再 parse でも opener-embedded iftags を扱うため、callback 側にも `pageTags`を伝搬している。

## 後方互換性

- `parse(src)` / `parse(src, {})` / `parse(src, { settings, trackPositions })`は挙動が一切変わらない。
- `preprocessIftags(source, [])` / `preprocessIftags(source, ["..."])` も従来通り。
- `preprocessIftags(source, null)` は **意図的に挙動変更**。これまでテストでno-op を期待していた箇所は description のみ更新し、入力が block-level のみであれば期待値はそのまま通る。

## Test plan

- [x] `bun run lint` (10 warnings, 0 errors — 既存箇所のみ)
- [x] `bun run format`
- [x] `bun run typecheck`
- [x] `bun test` (1292 pass / 0 fail)
- [x] 新規テスト:
  - `tests/unit/module/iftags/preprocess.test.ts`: null モードでのopener-embedded 畳み込み、quoted attribute 内 `]]` 保護、`[[[` link 非干渉、ネスト iftags、改行 depth リセットの 7 ケース
  - `tests/unit/parser/parser.test.ts`: `parse(src, { pageTags: ... })`の挙動を `pageTags` の 4 値で検証する 4 ケース
- [x] `tests/integration/fixture-*.test.ts` の既存 fixture も全通過（回帰なし）
- [ ] release 後、wpv4 / wdmock-cf 等の利用側で `parse(src, { pageTags })` に差し替えて opener-embedded iftags が`<div>` として正しくレンダリングされることを実機確認