### PR TITLE
fix(parser): [[include]] 末尾の余分な ] を許容して terminator を見つける

### DIFF
--- a/packages/parser/src/parser/rules/block/module/include/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/include/resolve.ts
@@ -172,15 +172,26 @@ interface IncludeDirectiveMatch {
 
 /**
  * Returns `true` when everything between `pos` and the next newline (or
- * end of string) is whitespace — i.e. `pos` sits at the end of its line.
+ * end of string) is whitespace or stray `]` characters — i.e. `pos` sits
+ * at the end of its line, optionally trailed by extra `]` that spilled
+ * over from the directive's last attribute value.
+ *
+ * Wikidot wikitext occasionally contains directives whose final attribute
+ * value ends in `]`, e.g. `[[include foo |key=--]|]]`. When the closing
+ * `]]` is written without a separator (`[[include foo |key=--]]]`), the
+ * first `]]` after the value is the directive terminator and the
+ * remaining `]` belongs outside the directive. Without tolerating those
+ * trailing `]`, the scanner would fail to close the directive at line
+ * end and drop the whole include to raw text.
  */
 function isRestOfLineBlank(source: string, pos: number): boolean {
   for (let i = pos; i < source.length; i++) {
     const ch = source[i];
     if (ch === "\n") return true;
-    if (ch !== " " && ch !== "\t" && ch !== "\r") return false;
+    if (ch === " " || ch === "\t" || ch === "\r" || ch === "]") continue;
+    return false;
   }
-  return true; // reached EOF with only whitespace
+  return true; // reached EOF with only whitespace / trailing `]`
 }
 
 /**

--- a/tests/unit/module/include/resolve.test.ts
+++ b/tests/unit/module/include/resolve.test.ts
@@ -300,6 +300,29 @@ describe("resolveIncludes", () => {
       const source = "[[include tmpl |cap=[[[a]]]]]\n[[include tmpl |cap=[[[b]]]]]";
       expect(resolveIncludes(source, fetcher)).toBe("<<[[[a]]]>>\n<<[[[b]]]>>");
     });
+
+    test("multi-line directive closes when the terminating ]] is trailed by stray ]", () => {
+      // When a final attribute value ends in `]` and the directive's
+      // closing `]]` follows without a separator (`--]]]`), the first
+      // `]]` terminates the directive (capturing `--` as the value);
+      // the trailing `]` outside the directive is preserved as raw text.
+      const source = "[[include tmpl\n|cap= --]]]";
+      expect(resolveIncludes(source, fetcher)).toBe("<<-->>]");
+    });
+
+    test("multi-line directive with stray ]] tail and following content", () => {
+      // The trailing `]` after the directive close must remain in the
+      // output (not be swallowed by the directive).
+      const source = "[[include tmpl\n|cap= --]]]\n\nafter";
+      expect(resolveIncludes(source, fetcher)).toBe("<<-->>]\n\nafter");
+    });
+
+    test("multi-line directive with multiple stray ] characters", () => {
+      // `]]]]]` at the end: the first `]]` drives depth to zero; the
+      // remaining `]]]` is plain text outside the directive.
+      const source = "[[include tmpl\n|cap= x]]]]]";
+      expect(resolveIncludes(source, fetcher)).toBe("<<x>>]]]");
+    });
   });
 
   describe("default-value idiom (duplicate key)", () => {


### PR DESCRIPTION
## 背景

最後の引数値が `]` で終わる multi-line include — 例えば `[[include foo\n|key=val|bar=--]|]]` の改行省略形 `[[include foo\n|key=val|bar=--]]]` — で `scanIncludeDirectives` が terminator を見つけられず、include ディレクティブ全体が生テキストとして残ってしまっていた。

原因は `isRestOfLineBlank` の判定。`]]` で depth が 0 になった時点で「直後が空白＋改行なら terminator」と判定するが、`]]]` のように直後に `]` が漏れ出ているケースでは「空白ではない」として close を拒否し、ループが closeEnd を見つけられないまま directive を諦めていた。

## 変更点

`isRestOfLineBlank` の終端判定で `]` も whitespace と同様に skip する。これにより:

- `[[include tmpl\n|cap= --]]]` → `<<-->>]` (`]]` で directive close、余分な `]` は include 外の raw text として残る)
- `[[include tmpl\n|cap= --]]]\n\nafter` → `<<-->>]\n\nafter`
- `[[include tmpl\n|cap= x]]]]]` → `<<x>>]]]`

inline include (`[[include foo |arg=val]]`) や、attribute 内に `[[span]]...[[/span]]` を含むケース、`[[[link]]]` を含むケースには影響なし。

## 後方互換性

`]]` を見つけた瞬間に terminator として close する条件が緩和されるだけで、既存の close 条件 (opener-line または完全な行末 blank) でも従来通り close される。逆に既存の close 条件で raw text 化していたケースだけが新たに resolve されるようになるため、既存挙動への影響はない。

## Test plan

- [x] `bun run lint` (10 warnings, 0 errors — 既存箇所のみ)
- [x] `bun run format`
- [x] `bun run typecheck`
- [x] `bun test` (1295 pass / 0 fail)
- [x] 新規テスト 3 ケース (`tests/unit/module/include/resolve.test.ts`):
  - terminating `]]` の直後に stray `]` がある multi-line include
  - 上記 + 続けて他のコンテンツがある場合
  - stray `]` が複数連続する場合
- [ ] release 後、wpv4 を bump して実ページで include が解決されることを確認