### PR TITLE
fix(parser): ListPagesのtags@URLで/tag URLを解決する

### DIFF
--- a/packages/parser/src/parser/rules/block/module/listpages/url-resolution/fields.ts
+++ b/packages/parser/src/parser/rules/block/module/listpages/url-resolution/fields.ts
@@ -1,9 +1,9 @@
 import type { ListPagesQuery } from "../types";
 
 export type UrlResolvableField =
-  | { attr: string; queryKey: StringUrlQueryKey; type: "string" }
-  | { attr: string; queryKey: NumberUrlQueryKey; type: "number" }
-  | { attr: string; queryKey: BooleanUrlQueryKey; type: "boolean" };
+  | { attr: string; queryKey: StringUrlQueryKey; type: "string"; urlAttrs?: readonly string[] }
+  | { attr: string; queryKey: NumberUrlQueryKey; type: "number"; urlAttrs?: readonly string[] }
+  | { attr: string; queryKey: BooleanUrlQueryKey; type: "boolean"; urlAttrs?: readonly string[] };
 
 type StringUrlQueryKey = Extract<
   keyof ListPagesQuery,
@@ -33,7 +33,7 @@ export const URL_RESOLVABLE_FIELDS: readonly UrlResolvableField[] = [
   { attr: "limit", queryKey: "limit", type: "number" },
   { attr: "per-page", queryKey: "perPage", type: "number" },
   { attr: "order", queryKey: "order", type: "string" },
-  { attr: "tags", queryKey: "tags", type: "string" },
+  { attr: "tags", queryKey: "tags", type: "string", urlAttrs: ["tag"] },
   { attr: "category", queryKey: "category", type: "string" },
   { attr: "parent", queryKey: "parent", type: "string" },
   { attr: "range", queryKey: "range", type: "string" },

--- a/packages/parser/src/parser/rules/block/module/listpages/url-resolution/params.ts
+++ b/packages/parser/src/parser/rules/block/module/listpages/url-resolution/params.ts
@@ -1,3 +1,5 @@
+import { URL_RESOLVABLE_FIELDS } from "./fields";
+
 /**
  * Parse URL path parameters like /offset/1/page2_limit/1.
  * Returns a map of parameter name -> value.
@@ -5,9 +7,10 @@
 export function parseUrlParams(url: string): Map<string, string> {
   const params = new Map<string, string>();
   const parts = url.split("/").filter(Boolean);
+  const pairStart = isUrlParameter(parts[0]) ? 0 : 1;
 
   // Skip the page name (first part), parse key/value pairs.
-  for (let i = 1; i < parts.length - 1; i += 2) {
+  for (let i = pairStart; i < parts.length - 1; i += 2) {
     const key = parts[i];
     const value = parts[i + 1];
     if (key && value) {
@@ -16,4 +19,12 @@ export function parseUrlParams(url: string): Map<string, string> {
   }
 
   return params;
+}
+
+const URL_PARAMETER_NAMES = new Set(
+  URL_RESOLVABLE_FIELDS.flatMap((field) => [field.attr, ...(field.urlAttrs ?? [])]),
+);
+
+function isUrlParameter(param: string | undefined): boolean {
+  return param !== undefined && URL_PARAMETER_NAMES.has(param);
 }

--- a/packages/parser/src/parser/rules/block/module/listpages/url-resolution/resolve.ts
+++ b/packages/parser/src/parser/rules/block/module/listpages/url-resolution/resolve.ts
@@ -25,13 +25,22 @@ export function resolveQuery(
     const rawValue = rawAttributes[field.attr];
     if (!rawValue) continue;
 
-    const resolvedValue = resolveUrlValue(rawValue, field.attr, urlParams, urlAttrPrefix);
+    const resolvedValue = resolveUrlValue(
+      rawValue,
+      getUrlParamNames(field),
+      urlParams,
+      urlAttrPrefix,
+    );
     if (resolvedValue === undefined) continue;
 
     assignResolvedUrlField(resolved, field, resolvedValue);
   }
 
   return resolved;
+}
+
+function getUrlParamNames(field: (typeof URL_RESOLVABLE_FIELDS)[number]): readonly string[] {
+  return field.urlAttrs ? [field.attr, ...field.urlAttrs] : [field.attr];
 }
 
 /**

--- a/packages/parser/src/parser/rules/block/module/listpages/url-resolution/value.ts
+++ b/packages/parser/src/parser/rules/block/module/listpages/url-resolution/value.ts
@@ -2,14 +2,14 @@
  * Resolve @URL|default format with actual URL parameters.
  *
  * @param rawValue - The raw attribute value (e.g., "@URL|0")
- * @param paramName - The parameter name (e.g., "offset")
+ * @param paramNames - The parameter name or names (e.g., "offset")
  * @param urlParams - Parsed URL parameters
  * @param prefix - Optional URL attribute prefix (e.g., "page2")
  * @returns Resolved value
  */
 export function resolveUrlValue(
   rawValue: string | undefined,
-  paramName: string,
+  paramNames: string | readonly string[],
   urlParams: Map<string, string>,
   prefix?: string,
 ): string | undefined {
@@ -20,6 +20,15 @@ export function resolveUrlValue(
   }
 
   const defaultValue = rawValue.includes("|") ? rawValue.split("|")[1] : undefined;
-  const actualParamName = prefix ? `${prefix}_${paramName}` : paramName;
-  return urlParams.get(actualParamName) ?? defaultValue;
+  for (const paramName of toParamNames(paramNames)) {
+    const actualParamName = prefix ? `${prefix}_${paramName}` : paramName;
+    const value = urlParams.get(actualParamName);
+    if (value !== undefined) return value;
+  }
+
+  return defaultValue;
+}
+
+function toParamNames(paramNames: string | readonly string[]): readonly string[] {
+  return typeof paramNames === "string" ? [paramNames] : paramNames;
 }

--- a/tests/unit/module/listpages/normalize.test.ts
+++ b/tests/unit/module/listpages/normalize.test.ts
@@ -529,6 +529,15 @@ describe("resolveQuery", () => {
     expect(result.order).toBe("titleAsc");
   });
 
+  test("resolves tags @URL from tag listing path", () => {
+    const req = createRequirement({ tags: "@URL|+fruit", limit: "@URL|10" });
+    const urlParams = parseUrlParams("/tag/vegetable/limit/5");
+    const result = resolveQuery(req, urlParams);
+
+    expect(result.tags).toBe("vegetable");
+    expect(result.limit).toBe(5);
+  });
+
   test("resolves boolean fields", () => {
     const req = createRequirement({ reverse: "@URL|false" });
     const urlParams = parseUrlParams("/scp-001/reverse/true");

--- a/tests/unit/module/listpages/url-resolver.test.ts
+++ b/tests/unit/module/listpages/url-resolver.test.ts
@@ -27,6 +27,18 @@ describe("parseUrlParams", () => {
     expect(params.get("page2_limit")).toBe("5");
     expect(params.get("page3_limit")).toBe("0");
   });
+
+  it("should parse tag listing URLs from the leading parameter", () => {
+    const params = parseUrlParams("/tag/fruit");
+    expect(params.get("tag")).toBe("fruit");
+  });
+
+  it("should parse tag listing URLs with trailing parameters", () => {
+    const params = parseUrlParams("/tag/fruit/offset/20/limit/5");
+    expect(params.get("tag")).toBe("fruit");
+    expect(params.get("offset")).toBe("20");
+    expect(params.get("limit")).toBe("5");
+  });
 });
 
 describe("resolveUrlValue", () => {


### PR DESCRIPTION
## 概要

ListPagesの`tags="@URL"`で、通常の`/tags/...`に加えてWikidotのタグ一覧URLである`/tag/...`も解決できるようにしました。

## 変更内容

- `URL_RESOLVABLE_FIELDS`の`tags`にURL側の別名として`tag`を追加
- `parseUrlParams`が先頭のURLパラメータも読めるようにし、`/tag/<tag>`形式を解析可能に変更
- `resolveUrlValue`が複数のURLパラメータ候補を順に参照できるように変更
- `/tag/<tag>`と後続パラメータ付きURL、`tags="@URL"`からの解決をテストに追加